### PR TITLE
Add outbreak tooltip and fetch uncertainty chart data

### DIFF
--- a/app/components/PercentageStats/index.tsx
+++ b/app/components/PercentageStats/index.tsx
@@ -3,6 +3,7 @@ import {
     ContainerCard,
     NumberOutput,
     ContainerCardProps,
+    Tooltip,
 } from '@the-deep/deep-ui';
 import { _cs } from '@togglecorp/fujs';
 
@@ -18,6 +19,8 @@ export interface Props {
     suffix?: string;
     statValue: number | null | undefined;
     subValue?: number;
+    newDeaths?: number | null;
+    newCasesPerMillion?: number | null;
 }
 
 function PercentageStats(props: Props) {
@@ -30,13 +33,27 @@ function PercentageStats(props: Props) {
         statValue,
         subValue,
         suffix,
+        newDeaths,
+        newCasesPerMillion,
     } = props;
 
     return (
         <ContainerCard
             className={_cs(className, styles.percentageStatsCard)}
             headingClassName={styles.percentageHeading}
-            heading={heading ? `Total number of ${heading} cases` : 'Total number of cases'}
+            heading={(
+                <>
+                    {heading ? `Total number of ${heading} cases` : 'Total number of cases'}
+                    <Tooltip>
+                        <div>
+                            {`Deaths: ${newDeaths}`}
+                        </div>
+                        <div>
+                            {`Cases Per Million: ${newCasesPerMillion}`}
+                        </div>
+                    </Tooltip>
+                </>
+            )}
             headingSize={headingSize}
             headerDescription={headerDescription}
             headerIconsContainerClassName={styles.iconContainer}
@@ -44,6 +61,7 @@ function PercentageStats(props: Props) {
             footerContentClassName={styles.valueAndSubValue}
             footerContent={(
                 <>
+
                     <NumberOutput
                         className={styles.valueText}
                         value={statValue}

--- a/app/components/PercentageStats/index.tsx
+++ b/app/components/PercentageStats/index.tsx
@@ -14,6 +14,7 @@ export interface Props {
     className?: string;
     icon?: React.ReactNode;
     heading?: React.ReactNode;
+    indicatorDescription?: string | null;
     headerDescription?: React.ReactNode;
     headingSize?: headingSizeType;
     suffix?: string;
@@ -30,6 +31,7 @@ function PercentageStats(props: Props) {
         heading,
         headingSize = 'extraSmall',
         headerDescription,
+        indicatorDescription,
         statValue,
         subValue,
         suffix,
@@ -43,15 +45,21 @@ function PercentageStats(props: Props) {
             headingClassName={styles.percentageHeading}
             heading={(
                 <>
-                    {heading ? `Total number of ${heading} cases` : 'Total number of cases'}
-                    <Tooltip>
-                        <div>
-                            {`Deaths: ${newDeaths}`}
-                        </div>
-                        <div>
-                            {`Cases Per Million: ${newCasesPerMillion}`}
-                        </div>
-                    </Tooltip>
+                    {indicatorDescription && indicatorDescription}
+                    {(!indicatorDescription && !heading) && 'Total number of cases'}
+                    {heading && (
+                        <>
+                            {`Total number of ${heading} cases`}
+                            <Tooltip>
+                                <div>
+                                    {`Deaths: ${newDeaths}`}
+                                </div>
+                                <div>
+                                    {`Cases Per Million: ${newCasesPerMillion}`}
+                                </div>
+                            </Tooltip>
+                        </>
+                    )}
                 </>
             )}
             headingSize={headingSize}

--- a/app/components/PercentageStats/index.tsx
+++ b/app/components/PercentageStats/index.tsx
@@ -45,7 +45,7 @@ function PercentageStats(props: Props) {
             headingClassName={styles.percentageHeading}
             heading={(
                 <>
-                    {indicatorDescription && indicatorDescription}
+                    {indicatorDescription}
                     {(!indicatorDescription && !heading) && 'Total number of cases'}
                     {heading && (
                         <>

--- a/app/components/UncertaintyChart/index.tsx
+++ b/app/components/UncertaintyChart/index.tsx
@@ -12,16 +12,24 @@ import {
     ContainerCard,
 } from '@the-deep/deep-ui';
 import { _cs } from '@togglecorp/fujs';
-
-import { rangeData } from '#utils/dummyData';
 import styles from './styles.css';
+
+export interface UncertainData {
+    indicatorValue?: string | null;
+    date: string;
+    uncertainRange: (string | undefined)[];
+}
 
 interface Props {
     className?: string;
+    uncertainData: UncertainData[] | undefined;
 }
 
 function UncertaintyChart(props: Props) {
-    const { className } = props;
+    const {
+        className,
+        uncertainData,
+    } = props;
 
     return (
         <ContainerCard
@@ -35,7 +43,7 @@ function UncertaintyChart(props: Props) {
                 className={styles.responsiveContainer}
             >
                 <ComposedChart
-                    data={rangeData}
+                    data={uncertainData}
                 >
                     <XAxis
                         dataKey="date"
@@ -51,14 +59,15 @@ function UncertaintyChart(props: Props) {
                             position: 'insideBottomLeft',
                             offset: 16,
                         }}
+                        domain={[0, 100]}
                     />
                     <Area
-                        dataKey="uncertainData"
+                        dataKey="uncertainRange"
                         stroke="#8DD2B1"
                         fill="#8DD2B1"
                     />
                     <Line
-                        dataKey="amt"
+                        dataKey="indicatorValue"
                         stroke="#2F9C67"
                         strokeWidth={2}
                         dot={{

--- a/app/components/UncertaintyChart/index.tsx
+++ b/app/components/UncertaintyChart/index.tsx
@@ -17,7 +17,7 @@ import styles from './styles.css';
 export interface UncertainData {
     indicatorValue?: string | null;
     date: string;
-    uncertainRange: (string | undefined)[];
+    uncertainRange: string[];
 }
 
 interface Props {

--- a/app/views/Dashboard/Country/index.tsx
+++ b/app/views/Dashboard/Country/index.tsx
@@ -167,6 +167,7 @@ function Country(props: Props) {
 
     const countryVariables = useMemo((): CountryQueryVariables => ({
         iso3: filterValues?.country ?? 'AFG',
+        // FIXME: filter needed to be handle from backend
         gte: '2021-08-01',
         contextIndicatorId: 'total_cases',
         disaggregationIso3: filterValues?.country ?? 'AFG',
@@ -174,6 +175,7 @@ function Country(props: Props) {
         uncertaintyIso3: filterValues?.country ?? 'AFG',
         subvariable: filterValues?.subvariable ?? '',
         indicatorId: filterValues?.indicator,
+        // NOTE: Only Global response needed
         category: 'Global',
         uncertaintyEmergency: filterValues?.outbreak ?? '',
     }), [
@@ -266,17 +268,21 @@ function Country(props: Props) {
 
     const uncertaintyChart: UncertainData[] | undefined = useMemo(() => (
         countryResponse?.dataCountryLevel.map((country) => {
-            const negativeRange = ((country?.indicatorValue && country?.errorMargin)
-                && country?.indicatorValue - country?.errorMargin);
-            const positiveRange = ((country?.indicatorValue && country?.errorMargin)
-                && country?.indicatorValue + country?.errorMargin);
+            const negativeRange = decimalToPercentage(
+                (country?.indicatorValue && country?.errorMargin)
+                && country?.indicatorValue - country?.errorMargin,
+            );
+            const positiveRange = decimalToPercentage(
+                (country?.indicatorValue && country?.errorMargin)
+                && country?.indicatorValue + country?.errorMargin,
+            );
 
             if (country.interpolated) {
                 return {
                     date: getShortMonth(country.indicatorMonth),
                     uncertainRange: [
-                        decimalToPercentage(negativeRange),
-                        decimalToPercentage(positiveRange),
+                        negativeRange ?? '',
+                        positiveRange ?? '',
                     ],
                 };
             }
@@ -284,8 +290,8 @@ function Country(props: Props) {
                 indicatorValue: decimalToPercentage(country.indicatorValue),
                 date: getShortMonth(country.indicatorMonth),
                 uncertainRange: [
-                    decimalToPercentage(negativeRange),
-                    decimalToPercentage(positiveRange),
+                    negativeRange ?? '',
+                    positiveRange ?? '',
                 ],
             };
         })
@@ -514,7 +520,7 @@ function Country(props: Props) {
                             />
                             <UncertaintyChart
                                 className={styles.indicatorsChart}
-                                uncertainData={uncertaintyChart ?? []}
+                                uncertainData={(uncertaintyChart && uncertaintyChart) ?? []}
                             />
                             {(genderDisaggregation && genderDisaggregation.length > 0
                                 && ageDisaggregation && ageDisaggregation.length > 0

--- a/app/views/Dashboard/Country/index.tsx
+++ b/app/views/Dashboard/Country/index.tsx
@@ -26,6 +26,8 @@ import {
     NumberOutput,
 } from '@the-deep/deep-ui';
 import { useQuery, gql } from '@apollo/client';
+import { IoInformationCircle } from 'react-icons/io5';
+import { BiLinkExternal } from 'react-icons/bi';
 
 import UncertaintyChart from '#components/UncertaintyChart';
 import PercentageStats from '#components/PercentageStats';
@@ -54,6 +56,8 @@ interface EmergencyItems {
     contextIndicatorValue?: number | null;
     contextIndicatorId: string;
     contextDate: string;
+    newDeaths?: number | null;
+    newCasesPerMillion?: number | null;
 }
 interface CountryWiseOutbreakCases extends EmergencyItems {
     key: string;
@@ -97,6 +101,8 @@ const COUNTRY_PROFILE = gql`
             internetAccessRegion
             economicSupportIndexRegion
             medicalStaffRegion
+            newCasesPerMillion
+            newDeaths
         }
         disaggregation {
             ageDisaggregation(iso3: $disaggregationIso3) {
@@ -212,10 +218,16 @@ function Country(props: Props) {
                 {
                     ...getLatestDateItems(emergencyItems),
                     key: emergency,
+                    newDeaths: countryResponse?.countryProfile.newDeaths,
+                    newCasesPerMillion: countryResponse?.countryProfile.newCasesPerMillion,
                 }
             ))
         );
-    }, [countryResponse?.contextualData]);
+    }, [
+        countryResponse?.contextualData,
+        countryResponse?.countryProfile.newCasesPerMillion,
+        countryResponse?.countryProfile.newDeaths,
+    ]);
 
     const ageDisaggregation = useMemo(() => countryResponse
         ?.disaggregation.ageDisaggregation.map((age) => (
@@ -333,6 +345,8 @@ function Country(props: Props) {
     const statusRendererParams = useCallback((_, data: CountryWiseOutbreakCases) => ({
         heading: data.emergency,
         statValue: data.contextIndicatorValue,
+        newDeaths: data.newDeaths,
+        newCasesPerMillion: data.newCasesPerMillion,
     }), []);
 
     const readinessRendererParams = useCallback((_, data: ScoreCardProps) => ({
@@ -499,7 +513,10 @@ function Country(props: Props) {
                     headingClassName={styles.countryHeading}
                     headerIcons={(
                         // FIX ME: COUNTRY AVATAR
-                        <img src="https://picsum.photos/50" alt="country-avatar" />
+                        <img
+                            src={`https://rcce-dashboard.s3.eu-west-3.amazonaws.com/flags/${filterValues?.country}.png`}
+                            alt="country-avatar"
+                        />
                     )}
                     headingSize="small"
                     heading={countryResponse?.countryProfile.countryName}
@@ -669,9 +686,24 @@ function Country(props: Props) {
             <ContainerCard
                 className={styles.perceptionWrapper}
                 contentClassName={styles.perceptionCard}
-                footerContent="Data collection not completed - as of March 31st"
+                heading="Sources"
+                headingSize="extraSmall"
             >
-                <p>COVID-19 Vaccine Perceptions in Africa</p>
+                <div
+                    className={styles.infoIcon}
+                >
+                    <IoInformationCircle />
+                </div>
+                <p>
+                    {`COVID-19 Vaccine Perceptions in ${countryResponse?.countryProfile.countryName}
+                    (${countryResponse?.countryProfile.countryName} CDC)`}
+                </p>
+                <a
+                    href="https://www.rcce-collective.net/data/data-tracker/"
+                    className={styles.linkIcon}
+                >
+                    <BiLinkExternal />
+                </a>
             </ContainerCard>
         </div>
     );

--- a/app/views/Dashboard/Country/styles.css
+++ b/app/views/Dashboard/Country/styles.css
@@ -114,8 +114,9 @@
 
             .country-avatar {
                 img {
-                    border: var(--width-separator-thin) solid var(--color-separator-light);
                     border-radius: var(--dui-border-radius-avatar);
+                    width: 64px;
+                    height: 64px;
                 }
             }
 
@@ -163,14 +164,23 @@
 
     .perception-wrapper {
         display: flex;
-        flex-direction: column;
         padding: var(--dui-spacing-medium);
 
         .perception-card {
-            width: 20rem;
+            display: flex;
+            align-items: center;
+            width: 33rem;
+            gap: var(--dui-spacing-small);
 
             p {
                 padding-left: var(--dui-spacing-small);
+            }
+            .info-icon {
+                color: var(--color-text-title);
+                font-size: var(--dui-font-size-extra-large);
+            }
+            .link-icon {
+                font-size: var(--dui-font-size-extra-large);
             }
         }
     }

--- a/app/views/Dashboard/Country/styles.css
+++ b/app/views/Dashboard/Country/styles.css
@@ -161,27 +161,19 @@
         }
     }
 
-
-    .perception-wrapper {
+    .perception-card {
         display: flex;
-        padding: var(--dui-spacing-medium);
+        justify-content: space-between;
+        width: 31rem;
 
-        .perception-card {
-            display: flex;
-            align-items: center;
-            width: 33rem;
-            gap: var(--dui-spacing-small);
-
-            p {
-                padding-left: var(--dui-spacing-small);
-            }
-            .info-icon {
-                color: var(--color-text-title);
-                font-size: var(--dui-font-size-extra-large);
-            }
-            .link-icon {
-                font-size: var(--dui-font-size-extra-large);
-            }
+        p {
+            padding-left: var(--dui-spacing-small);
         }
+
+        .info-icon {
+            color: var(--color-text-title);
+            font-size: var(--dui-font-size-extra-large);
+        }
+
     }
 }

--- a/app/views/Dashboard/Overview/PercentageCardGroup/index.tsx
+++ b/app/views/Dashboard/Overview/PercentageCardGroup/index.tsx
@@ -49,6 +49,9 @@ function PercentageCardGroup(props: PercentageCardGroupProps) {
                 statValue={90}
                 suffix={(uncertaintyChartActive ? '%' : 'M')}
             />
+            { /* FIXME: (for Priyesh) Either include data in Uncertainty Chart
+                or remove the component altogether
+               */}
             {uncertaintyChartActive
                 ? <UncertainityChart />
                 : (


### PR DESCRIPTION
- Addresses #36 #35 #86 

## Changes

- Tooltip over the outbreak card
- fetch uncertainty chart data
- fetch indicator name status component

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
