### PR TITLE
Add navigation from combined indicators page

### DIFF
--- a/app/components/ProgressBar/index.tsx
+++ b/app/components/ProgressBar/index.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { _cs, isNotDefined } from '@togglecorp/fujs';
+import { Button } from '@the-deep/deep-ui';
 
 import styles from './styles.css';
 
@@ -8,7 +9,6 @@ export interface Props {
     barHeight?: number;
     suffix?: string;
     barName: string | undefined;
-    id: number;
     title: string | undefined;
     valueTitle?: string | undefined;
     color?: string;
@@ -19,6 +19,9 @@ export interface Props {
     region?: string;
     showRegionalValue?: boolean;
     isNumberValue?: boolean;
+    indicatorId?: string;
+    subVariable?: string;
+    onTitleClick?: (indicatorId?: string, subVariable?: string) => void;
 }
 
 function ProgressBar(props: Props) {
@@ -27,7 +30,6 @@ function ProgressBar(props: Props) {
         barHeight = 8,
         suffix,
         barName,
-        id,
         title,
         valueTitle,
         color,
@@ -38,6 +40,9 @@ function ProgressBar(props: Props) {
         region,
         showRegionalValue = false,
         isNumberValue = false,
+        onTitleClick,
+        indicatorId,
+        subVariable,
     } = props;
 
     const countryPercentage = useMemo(() => {
@@ -54,6 +59,17 @@ function ProgressBar(props: Props) {
         isNumberValue,
     ]);
 
+    const handleTitleClick = useCallback(() => {
+        if (!onTitleClick) {
+            return;
+        }
+        onTitleClick(indicatorId, subVariable);
+    }, [
+        onTitleClick,
+        indicatorId,
+        subVariable,
+    ]);
+
     const subValuePercentage = useMemo(
         () => (
             subValue && totalValue
@@ -68,10 +84,19 @@ function ProgressBar(props: Props) {
     return (
         <div className={_cs(className, styles.progressInfo)}>
             <div className={styles.progressTitle}>
-                {barName}
-                <div
-                    title={title}
-                >
+                {indicatorId
+                    ? (
+                        <Button
+                            className={styles.titleButton}
+                            name={undefined}
+                            onClick={handleTitleClick}
+                            variant="transparent"
+                        >
+                            {barName}
+                        </Button>
+                    )
+                    : barName}
+                <div title={title}>
                     {icon}
                 </div>
             </div>
@@ -83,7 +108,7 @@ function ProgressBar(props: Props) {
                 >
                     <div
                         className={styles.progressBarStyle}
-                        key={id}
+                        key={undefined}
                         style={{
                             width: `${countryPercentage}%`,
                             backgroundColor: color ?? 'blue',

--- a/app/components/ProgressBar/styles.css
+++ b/app/components/ProgressBar/styles.css
@@ -7,6 +7,11 @@
         display: flex;
         align-items: center;
         gap: var(--dui-spacing-small);
+
+        .title-button {
+            padding: 0;
+            font-weight: var(--dui-font-weight-normal);
+        }
     }
 
     .progress-value-wrapper {

--- a/app/utils/dummyData.ts
+++ b/app/utils/dummyData.ts
@@ -12,7 +12,7 @@ export interface PercentageStatsProps {
 export const progressDataOne: ProgressBarRendererProps[] = [
     {
         barName: 'Cameroon',
-        id: 1,
+        id: '1',
         title: 'Vulnerable cases',
         color: 'var(--dui-color-progress-alt)',
         value: 130,
@@ -20,7 +20,7 @@ export const progressDataOne: ProgressBarRendererProps[] = [
     },
     {
         barName: 'Algeria',
-        id: 2,
+        id: '2',
         title: 'Vulnerable cases',
         color: 'var(--dui-color-progress-alt)',
         value: 50,
@@ -28,7 +28,7 @@ export const progressDataOne: ProgressBarRendererProps[] = [
     },
     {
         barName: 'Bulgaria',
-        id: 3,
+        id: '3',
         title: 'Vulnerable cases',
         color: 'var(--dui-color-progress-alt)',
         value: 99.5,
@@ -36,7 +36,7 @@ export const progressDataOne: ProgressBarRendererProps[] = [
     },
     {
         barName: 'Democratic Republic of Congo',
-        id: 4,
+        id: '4',
         title: 'Vulnerable cases',
         color: 'var(--dui-color-progress-alt)',
         value: 105,
@@ -44,7 +44,7 @@ export const progressDataOne: ProgressBarRendererProps[] = [
     },
     {
         barName: 'Belarus',
-        id: 5,
+        id: '5',
         title: 'Vulnerable cases',
         color: 'var(--dui-color-progress-alt)',
         value: 125,

--- a/app/views/Dashboard/CombinedIndicators/TopicCard/index.tsx
+++ b/app/views/Dashboard/CombinedIndicators/TopicCard/index.tsx
@@ -1,12 +1,16 @@
 import React, { useCallback } from 'react';
 import { IoInformationCircleOutline } from 'react-icons/io5';
-
+import {
+    isDefined,
+} from '@togglecorp/fujs';
 import {
     ContainerCard,
     List,
 } from '@the-deep/deep-ui';
 
 import ProgressBar from '#components/ProgressBar';
+import { FilterType } from '#views/Dashboard/Filters';
+import { TabTypes } from '#views/Dashboard';
 
 import { IndicatorDataType } from '..';
 
@@ -18,6 +22,9 @@ interface Props {
     indicatorKey: string;
     indicators: IndicatorDataType[];
     showRegionalValue: boolean;
+    filterValues: FilterType | undefined;
+    setFilterValues: React.Dispatch<React.SetStateAction<FilterType | undefined>>;
+    setActiveTab: React.Dispatch<React.SetStateAction<TabTypes | undefined>>;
 }
 
 function TopicCard(props: Props) {
@@ -25,7 +32,37 @@ function TopicCard(props: Props) {
         indicatorKey,
         indicators,
         showRegionalValue,
+        filterValues,
+        setFilterValues,
+        setActiveTab,
     } = props;
+
+    const handleIndicatorClick = useCallback((indicatorId?: string, subVariable?: string) => {
+        if (isDefined(filterValues?.country)) {
+            setActiveTab('country');
+
+            if (isDefined(indicatorId)) {
+                setFilterValues((old) => ({
+                    ...old,
+                    indicator: indicatorId,
+                    subvariable: subVariable,
+                }));
+            }
+        } else {
+            setActiveTab('overview');
+
+            if (isDefined(indicatorId)) {
+                setFilterValues((old) => ({
+                    ...old,
+                    indicator: indicatorId,
+                }));
+            }
+        }
+    }, [
+        filterValues,
+        setActiveTab,
+        setFilterValues,
+    ]);
 
     const indicatorRendererParams = useCallback((_: string, data: IndicatorDataType) => ({
         className: styles.indicatorItem,
@@ -37,12 +74,17 @@ function TopicCard(props: Props) {
         value: data.indicatorValue ?? 0,
         subValue: data.indicatorValueRegional ?? 0,
         totalValue: 1,
-        id: +`${data.indicatorId}-${data.subvariable}`,
+        indicatorId: data.indicatorId,
+        subVariable: data.indicatorId,
         icon: <IoInformationCircleOutline />,
         color: '#98a6b5',
         region: data.region ?? '',
         showRegionalValue,
-    }), [showRegionalValue]);
+        onTitleClick: handleIndicatorClick,
+    }), [
+        showRegionalValue,
+        handleIndicatorClick,
+    ]);
 
     const indicatorKeySelector = (d: IndicatorDataType) => d.subvariable;
 

--- a/app/views/Dashboard/CombinedIndicators/index.tsx
+++ b/app/views/Dashboard/CombinedIndicators/index.tsx
@@ -20,6 +20,7 @@ import {
     CombinedIndicatorsGlobalQuery,
     CombinedIndicatorsGlobalQueryVariables,
 } from '#generated/types';
+import { TabTypes } from '#views/Dashboard';
 
 import TopicCard from './TopicCard';
 import { AdvancedOptionType } from '../AdvancedFilters';
@@ -138,6 +139,9 @@ interface ThematicProps {
     thematicName: string;
     indicators: IndicatorDataType[];
     showRegionalValue: boolean;
+    filterValues: FilterType | undefined;
+    setFilterValues: React.Dispatch<React.SetStateAction<FilterType | undefined>>;
+    setActiveTab: React.Dispatch<React.SetStateAction<TabTypes | undefined>>;
 }
 
 function ThematicRenderer(props: ThematicProps) {
@@ -145,6 +149,9 @@ function ThematicRenderer(props: ThematicProps) {
         thematicName,
         indicators,
         showRegionalValue,
+        filterValues,
+        setFilterValues,
+        setActiveTab,
     } = props;
 
     const topicKeySelector = (d: SeparatedThematic) => d.key;
@@ -168,7 +175,15 @@ function ThematicRenderer(props: ThematicProps) {
         indicatorKey: key,
         indicators: data.items,
         showRegionalValue,
-    }), [showRegionalValue]);
+        filterValues,
+        setFilterValues,
+        setActiveTab,
+    }), [
+        showRegionalValue,
+        setActiveTab,
+        filterValues,
+        setFilterValues,
+    ]);
 
     return (
         <div
@@ -194,6 +209,8 @@ interface Props {
     className?: string;
     filterValues?: FilterType | undefined;
     advancedFilterValues?: AdvancedOptionType | undefined;
+    setFilterValues: React.Dispatch<React.SetStateAction<FilterType | undefined>>;
+    setActiveTab: React.Dispatch<React.SetStateAction<TabTypes | undefined>>;
 }
 
 function CombinedIndicators(props: Props) {
@@ -201,6 +218,8 @@ function CombinedIndicators(props: Props) {
         className,
         filterValues,
         advancedFilterValues,
+        setFilterValues,
+        setActiveTab,
     } = props;
 
     const {
@@ -305,8 +324,13 @@ function CombinedIndicators(props: Props) {
         thematicName: item.key,
         indicators: item.items,
         showRegionalValue: isDefined(filterValues?.country),
+        setFilterValues,
+        filterValues,
+        setActiveTab,
     }), [
-        filterValues?.country,
+        filterValues,
+        setFilterValues,
+        setActiveTab,
     ]);
     const topicKeySelector = (d: SeparatedThematic) => d.key;
     const loading = combinedIndicatorsLoading

--- a/app/views/Dashboard/Overview/MapView/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/index.tsx
@@ -299,7 +299,6 @@ function MapView(props: MapViewProps) {
             suffix: isIndicatorSelected ? '%' : 'M',
             barName: data.countryName,
             title: data.countryName,
-            id: +data.countryId,
             value: data.contextIndicatorValue ?? undefined,
             totalValue: 0,
             color: '#98A6B5',

--- a/app/views/Dashboard/index.tsx
+++ b/app/views/Dashboard/index.tsx
@@ -198,6 +198,8 @@ function Dashboard() {
                         <CombinedIndicators
                             filterValues={filterValues}
                             advancedFilterValues={advancedFilterValues}
+                            setFilterValues={setFilterValues}
+                            setActiveTab={setActiveTab}
                         />
                     </TabPanel>
                 </div>


### PR DESCRIPTION
- Depends on feature/add-table-and-map-query

## Changes

* Handle navigation from combined indicators to overview and country

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
