### PR TITLE
Change subindicator after indicator is changed in filters

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -20,24 +20,24 @@
 
             * {
                 box-sizing: border-box;
-                scrollbar-color: var(--tui-color-foreground-scrollbar) var(--tui-color-background-scrollbar);
+                scrollbar-color: var(--dui-color-foreground-scrollbar) var(--dui-color-background-scrollbar);
                 scrollbar-width: thin;
             }
 
             ::-webkit-scrollbar {
-                background-color: var(--tui-color-background-scrollbar);
-                width: var(--tui-width-scrollbar);
-                height: var(--tui-width-scrollbar);
-                background-color: var(--tui-color-background-scrollbar);
+                background-color: var(--dui-color-background-scrollbar);
+                width: var(--dui-width-scrollbar);
+                height: var(--dui-width-scrollbar);
+                background-color: var(--dui-color-background-scrollbar);
             }
 
             ::-webkit-scrollbar-track {
-                background-color: var(--tui-color-background-scrollbar);
+                background-color: var(--dui-color-background-scrollbar);
             }
 
             ::-webkit-scrollbar-thumb {
-                border-radius: var(--tui-radius-scrollbar-border);
-                background-color: var(--tui-color-foreground-scrollbar);
+                border-radius: var(--dui-radius-scrollbar-border);
+                background-color: var(--dui-color-foreground-scrollbar);
             }
         </style>
     </head>

--- a/app/utils/dummyData.ts
+++ b/app/utils/dummyData.ts
@@ -1,5 +1,3 @@
-import { Props as ProgressBarRendererProps } from '#components/ProgressBar';
-
 type Bounds = [number, number, number, number];
 
 export interface PercentageStatsProps {
@@ -8,49 +6,6 @@ export interface PercentageStatsProps {
     statValue: number;
     suffix: string;
 }
-
-export const progressDataOne: ProgressBarRendererProps[] = [
-    {
-        barName: 'Cameroon',
-        id: '1',
-        title: 'Vulnerable cases',
-        color: 'var(--dui-color-progress-alt)',
-        value: 130,
-        totalValue: 200,
-    },
-    {
-        barName: 'Algeria',
-        id: '2',
-        title: 'Vulnerable cases',
-        color: 'var(--dui-color-progress-alt)',
-        value: 50,
-        totalValue: 200,
-    },
-    {
-        barName: 'Bulgaria',
-        id: '3',
-        title: 'Vulnerable cases',
-        color: 'var(--dui-color-progress-alt)',
-        value: 99.5,
-        totalValue: 200,
-    },
-    {
-        barName: 'Democratic Republic of Congo',
-        id: '4',
-        title: 'Vulnerable cases',
-        color: 'var(--dui-color-progress-alt)',
-        value: 105,
-        totalValue: 200,
-    },
-    {
-        barName: 'Belarus',
-        id: '5',
-        title: 'Vulnerable cases',
-        color: 'var(--dui-color-progress-alt)',
-        value: 125,
-        totalValue: 200,
-    },
-];
 
 export const boundsData: Bounds = [80.088425, 26.397898, 88.174804, 30.422717];
 

--- a/app/views/Dashboard/AdvancedFilters/styles.css
+++ b/app/views/Dashboard/AdvancedFilters/styles.css
@@ -1,10 +1,11 @@
 .advanced-filters {
     display: flex;
     align-items: flex-end;
+    flex-wrap: wrap;
     border: 1px solid var(--dui-color-separator);
     border-radius: var(--dui-border-radius-card);
     background-color: var(--dui-color-background);
-    padding: var(--dui-spacing-medium);
+    padding: var(--dui-spacing-large);
     gap: var(--dui-spacing-large);
 
     .filter{
@@ -12,13 +13,21 @@
     }
 
     .keywords {
-        flex-grow: 1;
-        border-radius: 5px;
+        border-radius: 2rem;
+        min-width: 18rem;
 
         :global {
             .react-select__control {
                 /* TODO: Fix this after the design is finalized for this input */
                 border-radius: 2rem;
+                border-color: var(--dui-color-separator);
+                min-height: 36px;
+            }
+            .css-tlfecz-indicatorContainer {
+                padding: 6px;
+            }
+            .react-select__input-container {
+                margin: 0;
             }
         }
     }

--- a/app/views/Dashboard/CombinedIndicators/TopicCard/styles.css
+++ b/app/views/Dashboard/CombinedIndicators/TopicCard/styles.css
@@ -8,7 +8,7 @@
 
         .indicator-item {
             flex-basis: 30%;
-            border-bottom: var(--dui-width-separator-thin) solid var(--dui-color-line-separator);
+            /* border-bottom: var(--dui-width-separator-thin) solid var(--dui-color-line-separator); */
         }
     }
 }

--- a/app/views/Dashboard/CombinedIndicators/index.tsx
+++ b/app/views/Dashboard/CombinedIndicators/index.tsx
@@ -333,9 +333,23 @@ function CombinedIndicators(props: Props) {
         setActiveTab,
     ]);
     const topicKeySelector = (d: SeparatedThematic) => d.key;
-    const loading = combinedIndicatorsLoading
-        && regionalCombinedIndicatorsLoading
-        && globalCombinedIndicatorsLoading;
+
+    const loading = useMemo(() => {
+        if (isDefined(filterValues?.country)) {
+            return combinedIndicatorsLoading;
+        }
+
+        if (isDefined(filterValues?.region)) {
+            return regionalCombinedIndicatorsLoading;
+        }
+
+        return globalCombinedIndicatorsLoading;
+    }, [
+        filterValues,
+        combinedIndicatorsLoading,
+        regionalCombinedIndicatorsLoading,
+        globalCombinedIndicatorsLoading,
+    ]);
 
     return (
         <div className={_cs(className, styles.combinedIndicatorWrapper)}>

--- a/app/views/Dashboard/Country/index.tsx
+++ b/app/views/Dashboard/Country/index.tsx
@@ -659,167 +659,166 @@ function Country(props: Props) {
                     )}
                     headingSize="small"
                     heading={countryResponse?.countryProfile.countryName}
+                    contentClassName={styles.countryDetails}
                 >
-                    <div className={styles.countryDetails}>
-                        {isDefined(countryResponse?.countryProfile.populationSize) && (
-                            <TextOutput
-                                className={styles.countryTextOutput}
-                                valueContainerClassName={styles.valueText}
-                                labelContainerClassName={styles.labelText}
-                                hideLabelColon
-                                label="Population"
-                                value={(
-                                    <NumberOutput
-                                        value={countryResponse?.countryProfile.populationSize}
-                                    />
-                                )}
-                            />
-                        )}
-                        {isDefined(internetAccess) && (
-                            <TextOutput
-                                className={styles.countryTextOutput}
-                                valueContainerClassName={styles.valueText}
-                                labelContainerClassName={styles.labelText}
-                                hideLabelColon
-                                label="Internet access"
-                                value={(
-                                    <>
-                                        {`${internetAccess}%`}
-                                        {isDefined(internetAccessRegion) && (
-                                            <TextOutput
-                                                labelContainerClassName={styles.regionalText}
-                                                valueContainerClassName={styles.regionalText}
-                                                label={countryResponse?.countryProfile.region}
-                                                value={`${internetAccessRegion}%`}
-                                            />
-                                        )}
-                                    </>
-                                )}
-                            />
-                        )}
-                        {isDefined(literacyRate) && (
-                            <TextOutput
-                                className={styles.countryTextOutput}
-                                valueContainerClassName={styles.valueText}
-                                labelContainerClassName={styles.labelText}
-                                hideLabelColon
-                                label="Literacy rate"
-                                value={(
-                                    <>
-                                        {`${literacyRate}%`}
-                                        {isDefined(literacyRateRegion) && (
-                                            <TextOutput
-                                                labelContainerClassName={styles.regionalText}
-                                                valueContainerClassName={styles.regionalText}
-                                                label={countryResponse?.countryProfile.region}
-                                                value={`${literacyRateRegion}%`}
-                                            />
-                                        )}
-                                    </>
-                                )}
-                            />
-                        )}
-                        {isDefined(washAccessNational) && (
-                            <TextOutput
-                                className={styles.countryTextOutput}
-                                valueContainerClassName={styles.valueText}
-                                labelContainerClassName={styles.labelText}
-                                hideLabelColon
-                                label="Access to basic washing facilities"
-                                value={(
-                                    <>
-                                        {`${washAccessNational}%`}
-                                        {isDefined(washAccessNationalRegion) && (
-                                            <TextOutput
-                                                labelContainerClassName={styles.regionalText}
-                                                valueContainerClassName={styles.regionalText}
-                                                label={countryResponse?.countryProfile.region}
-                                                value={`${washAccessNationalRegion}%`}
-                                            />
-                                        )}
-                                    </>
-                                )}
-                            />
-                        )}
-                        {isDefined(countryResponse?.countryProfile.medicalStaff) && (
-                            <TextOutput
-                                className={styles.countryTextOutput}
-                                valueContainerClassName={styles.valueText}
-                                labelContainerClassName={styles.labelText}
-                                hideLabelColon
-                                label="Doctors and nurses per 1000 people"
-                                value={(
-                                    <>
-                                        {(countryResponse?.countryProfile.medicalStaff)?.toFixed(2)}
-                                        {isDefined(
-                                            countryResponse?.countryProfile.medicalStaffRegion,
-                                        ) && (
-                                            <TextOutput
-                                                labelContainerClassName={styles.regionalText}
-                                                valueContainerClassName={styles.regionalText}
-                                                label={countryResponse?.countryProfile.region}
-                                                value={(countryResponse
-                                                    ?.countryProfile.medicalStaffRegion)
-                                                    ?.toFixed(2)}
-                                            />
-                                        )}
-                                    </>
-                                )}
-                            />
-                        )}
-                        {isDefined(stringency) && (
-                            <TextOutput
-                                className={styles.countryTextOutput}
-                                valueContainerClassName={styles.valueText}
-                                labelContainerClassName={styles.labelText}
-                                hideLabelColon
-                                label="Stringency"
-                                value={(
-                                    <>
-                                        {`${stringency}%`}
-                                        {isDefined(stringencyRegion) && (
-                                            <TextOutput
-                                                labelContainerClassName={styles.regionalText}
-                                                valueContainerClassName={styles.regionalText}
-                                                label={countryResponse?.countryProfile.region}
-                                                value={`${stringencyRegion}%`}
-                                            />
-                                        )}
-                                    </>
-                                )}
-                            />
-                        )}
+                    {isDefined(countryResponse?.countryProfile.populationSize) && (
                         <TextOutput
                             className={styles.countryTextOutput}
                             valueContainerClassName={styles.valueText}
                             labelContainerClassName={styles.labelText}
                             hideLabelColon
-                            label="Regional cases %"
-                            value={`${regional}%`}
+                            label="Population"
+                            value={(
+                                <NumberOutput
+                                    value={countryResponse?.countryProfile.populationSize}
+                                />
+                            )}
                         />
-                        {isDefined(economicSupportIndex) && (
-                            <TextOutput
-                                className={styles.countryTextOutput}
-                                valueContainerClassName={styles.valueText}
-                                labelContainerClassName={styles.labelText}
-                                hideLabelColon
-                                label="Economic support index"
-                                value={(
-                                    <>
-                                        {`${economicSupportIndex}%`}
-                                        {isDefined(economicSupportIndexRegion) && (
-                                            <TextOutput
-                                                labelContainerClassName={styles.regionalText}
-                                                valueContainerClassName={styles.regionalText}
-                                                label={countryResponse?.countryProfile.region}
-                                                value={`${economicSupportIndexRegion}%`}
-                                            />
-                                        )}
-                                    </>
-                                )}
-                            />
-                        )}
-                    </div>
+                    )}
+                    {isDefined(internetAccess) && (
+                        <TextOutput
+                            className={styles.countryTextOutput}
+                            valueContainerClassName={styles.valueText}
+                            labelContainerClassName={styles.labelText}
+                            hideLabelColon
+                            label="Internet access"
+                            value={(
+                                <>
+                                    {`${internetAccess}%`}
+                                    {isDefined(internetAccessRegion) && (
+                                        <TextOutput
+                                            labelContainerClassName={styles.regionalText}
+                                            valueContainerClassName={styles.regionalText}
+                                            label={countryResponse?.countryProfile.region}
+                                            value={`${internetAccessRegion}%`}
+                                        />
+                                    )}
+                                </>
+                            )}
+                        />
+                    )}
+                    {isDefined(literacyRate) && (
+                        <TextOutput
+                            className={styles.countryTextOutput}
+                            valueContainerClassName={styles.valueText}
+                            labelContainerClassName={styles.labelText}
+                            hideLabelColon
+                            label="Literacy rate"
+                            value={(
+                                <>
+                                    {`${literacyRate}%`}
+                                    {isDefined(literacyRateRegion) && (
+                                        <TextOutput
+                                            labelContainerClassName={styles.regionalText}
+                                            valueContainerClassName={styles.regionalText}
+                                            label={countryResponse?.countryProfile.region}
+                                            value={`${literacyRateRegion}%`}
+                                        />
+                                    )}
+                                </>
+                            )}
+                        />
+                    )}
+                    {isDefined(washAccessNational) && (
+                        <TextOutput
+                            className={styles.countryTextOutput}
+                            valueContainerClassName={styles.valueText}
+                            labelContainerClassName={styles.labelText}
+                            hideLabelColon
+                            label="Access to basic washing facilities"
+                            value={(
+                                <>
+                                    {`${washAccessNational}%`}
+                                    {isDefined(washAccessNationalRegion) && (
+                                        <TextOutput
+                                            labelContainerClassName={styles.regionalText}
+                                            valueContainerClassName={styles.regionalText}
+                                            label={countryResponse?.countryProfile.region}
+                                            value={`${washAccessNationalRegion}%`}
+                                        />
+                                    )}
+                                </>
+                            )}
+                        />
+                    )}
+                    {isDefined(countryResponse?.countryProfile.medicalStaff) && (
+                        <TextOutput
+                            className={styles.countryTextOutput}
+                            valueContainerClassName={styles.valueText}
+                            labelContainerClassName={styles.labelText}
+                            hideLabelColon
+                            label="Doctors and nurses per 1000 people"
+                            value={(
+                                <>
+                                    {(countryResponse?.countryProfile.medicalStaff)?.toFixed(2)}
+                                    {isDefined(
+                                        countryResponse?.countryProfile.medicalStaffRegion,
+                                    ) && (
+                                        <TextOutput
+                                            labelContainerClassName={styles.regionalText}
+                                            valueContainerClassName={styles.regionalText}
+                                            label={countryResponse?.countryProfile.region}
+                                            value={(countryResponse
+                                                ?.countryProfile.medicalStaffRegion)
+                                                ?.toFixed(2)}
+                                        />
+                                    )}
+                                </>
+                            )}
+                        />
+                    )}
+                    {isDefined(stringency) && (
+                        <TextOutput
+                            className={styles.countryTextOutput}
+                            valueContainerClassName={styles.valueText}
+                            labelContainerClassName={styles.labelText}
+                            hideLabelColon
+                            label="Stringency"
+                            value={(
+                                <>
+                                    {`${stringency}%`}
+                                    {isDefined(stringencyRegion) && (
+                                        <TextOutput
+                                            labelContainerClassName={styles.regionalText}
+                                            valueContainerClassName={styles.regionalText}
+                                            label={countryResponse?.countryProfile.region}
+                                            value={`${stringencyRegion}%`}
+                                        />
+                                    )}
+                                </>
+                            )}
+                        />
+                    )}
+                    <TextOutput
+                        className={styles.countryTextOutput}
+                        valueContainerClassName={styles.valueText}
+                        labelContainerClassName={styles.labelText}
+                        hideLabelColon
+                        label="Regional cases %"
+                        value={`${regional}%`}
+                    />
+                    {isDefined(economicSupportIndex) && (
+                        <TextOutput
+                            className={styles.countryTextOutput}
+                            valueContainerClassName={styles.valueText}
+                            labelContainerClassName={styles.labelText}
+                            hideLabelColon
+                            label="Economic support index"
+                            value={(
+                                <>
+                                    {`${economicSupportIndex}%`}
+                                    {isDefined(economicSupportIndexRegion) && (
+                                        <TextOutput
+                                            labelContainerClassName={styles.regionalText}
+                                            valueContainerClassName={styles.regionalText}
+                                            label={countryResponse?.countryProfile.region}
+                                            value={`${economicSupportIndexRegion}%`}
+                                        />
+                                    )}
+                                </>
+                            )}
+                        />
+                    )}
                 </ContainerCard>
             </div>
             <div className={styles.perceptionCard}>

--- a/app/views/Dashboard/Country/styles.css
+++ b/app/views/Dashboard/Country/styles.css
@@ -27,6 +27,7 @@
 
                     .info-cards {
                         display: flex;
+                        flex-wrap: wrap-reverse;
                         gap: var(--dui-spacing-large);
                     }
 
@@ -136,7 +137,6 @@
                 .country-text-output {
                     align-items: center;
                     justify-content: space-between;
-                    border-bottom: var(--dui-width-separator-thin) solid var(--dui-color-line-separator);
                     height: 4rem;
                     font-size: var(--dui-font-size-medium);
 
@@ -155,6 +155,10 @@
                             font-size: var(--dui-font-size-small);
                             font-weight: var(--dui-font-weight-light);
                         }
+                    }
+
+                    &:not(:last-child) {
+                        border-bottom: var(--dui-width-separator-thin) solid var(--dui-color-line-separator);
                     }
                 }
             }

--- a/app/views/Dashboard/Filters/styles.css
+++ b/app/views/Dashboard/Filters/styles.css
@@ -4,16 +4,18 @@
     gap: var(--dui-spacing-medium);
 
     .filters {
-        display: flex;
+        display: inline-flex;
+        flex-wrap: wrap;
         gap: var(--dui-spacing-medium);
 
-        .left {
-            display: flex;
-            flex-grow: 1;
-            gap: var(--dui-spacing-medium);
-        }
-        .clear-button{
+        .clear-button {
+            justify-self: flex-end;
             flex-shrink: 0;
+        }
+
+        .indicator-select-input {
+            flex-grow: 1;
+            max-width: 40rem;
         }
     }
 }

--- a/app/views/Dashboard/index.tsx
+++ b/app/views/Dashboard/index.tsx
@@ -17,7 +17,11 @@ import Narratives from '#components/Narratives';
 import {
     NarrativeQuery,
     NarrativeQueryVariables,
+    CountryListQuery,
+    CountryListQueryVariables,
 } from '#generated/types';
+import { getRegionForCountry } from '#utils/common';
+
 import Overview from './Overview';
 import Country from './Country';
 import CombinedIndicators from './CombinedIndicators';
@@ -59,10 +63,31 @@ function Dashboard() {
         setAdvancedFilterValues,
     ] = useState<AdvancedOptionType | undefined>();
 
+    const {
+        data: countryList,
+        loading: countryListLoading,
+    } = useQuery<CountryListQuery, CountryListQueryVariables>(
+        COUNTRY_LIST,
+    );
+
     const handleActiveTabChange = (newActiveTab: TabTypes | undefined) => {
         setActiveTab(newActiveTab);
         if (newActiveTab === 'country') {
-            setFilterValues((oldFilterValues) => ({ ...oldFilterValues, country: 'AFG' }));
+            setFilterValues((oldFilterValues) => {
+                if (oldFilterValues?.country) {
+                    return oldFilterValues;
+                }
+
+                const newValueForRegion = {
+                    ...oldFilterValues,
+                    country: 'AFG',
+                    region: getRegionForCountry(
+                        'AFG',
+                        countryList?.countries ?? [],
+                    ) ?? undefined,
+                };
+                return newValueForRegion;
+            });
         }
     };
 
@@ -178,6 +203,8 @@ function Dashboard() {
                     onChange={setFilterValues}
                     advancedFilterValues={advancedFilterValues}
                     setAdvancedFilterValues={setAdvancedFilterValues}
+                    countries={countryList?.countries}
+                    countriesLoading={countryListLoading}
                 />
                 <div className={styles.content}>
                     <TabPanel name="overview">

--- a/app/views/Dashboard/styles.css
+++ b/app/views/Dashboard/styles.css
@@ -4,7 +4,6 @@
     flex-grow: 1;
     background-color: var(--color-background);
     padding: 0 var(--dui-spacing-ultra-large);
-    overflow-y: auto;
     gap: var(--dui-spacing-medium);
 
     .dashboard-buttons {


### PR DESCRIPTION
- Addresses #122 #123 #124 #126 
- Depends on server branch feature/add-table-and-map-query

## Changes

* Fix styling issues
* Select a default subvariable when indicator is selected
* Sort region list in filter options
* Fix region/country mismatch while switching tabs

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
