### PR TITLE
Fix line chart overflow

### DIFF
--- a/app/components/UncertaintyChart/index.tsx
+++ b/app/components/UncertaintyChart/index.tsx
@@ -22,8 +22,8 @@ export interface UncertainData {
     uncertainRange?: number[];
     minimumValue?: number;
     maximumValue?: number;
-    indicatorName?: string;
     region?: string;
+    indicatorName?: string | null;
 }
 
 const dateTickFormatter = (d: string) => getShortMonth(d);

--- a/app/components/UncertaintyChart/index.tsx
+++ b/app/components/UncertaintyChart/index.tsx
@@ -16,7 +16,6 @@ import { getShortMonth } from '#utils/common';
 import styles from './styles.css';
 
 export interface UncertainData {
-    id: string;
     emergency?: string;
     indicatorValue?: number | null;
     date: string;
@@ -111,6 +110,9 @@ function UncertaintyChart(props: Props) {
                         }}
                         tickFormatter={dateTickFormatter}
                     />
+                    {/* NOTE: don't need to determine the Y-axis domain
+                    this will auto calculate minium and maximum value
+                    based upon the data provided to chart. */}
                     <YAxis />
                     <Area
                         dataKey="uncertainRange"

--- a/app/components/UncertaintyChart/index.tsx
+++ b/app/components/UncertaintyChart/index.tsx
@@ -16,6 +16,7 @@ import { getShortMonth } from '#utils/common';
 import styles from './styles.css';
 
 export interface UncertainData {
+    id: string;
     emergency?: string;
     indicatorValue?: number | null;
     date: string;
@@ -25,7 +26,9 @@ export interface UncertainData {
     indicatorName?: string;
     region?: string;
 }
+
 const dateTickFormatter = (d: string) => getShortMonth(d);
+
 interface Props {
     className?: string;
     uncertainData: UncertainData[] | undefined;
@@ -34,13 +37,15 @@ interface Props {
     heading?: React.ReactNode;
 }
 
+interface Payload {
+    name?: string;
+    value?: number;
+    payload?: UncertainData;
+}
+
 interface TooltipProps {
     active?: boolean;
-    payload?: {
-        name?: string;
-        value?: number;
-        payload?: UncertainData;
-    }[];
+    payload?: Payload[];
 }
 
 function UncertaintyChart(props: Props) {

--- a/app/components/UncertaintyChart/index.tsx
+++ b/app/components/UncertaintyChart/index.tsx
@@ -20,10 +20,10 @@ export interface UncertainData {
     indicatorValue?: number | null;
     date: string;
     uncertainRange?: number[];
-    minimumValue?: number,
-    maximumValue?: number,
+    minimumValue?: number;
+    maximumValue?: number;
+    indicatorName?: string;
     region?: string;
-    indicatorName?: string | null;
 }
 const dateTickFormatter = (d: string) => getShortMonth(d);
 interface Props {
@@ -40,7 +40,7 @@ interface TooltipProps {
         name?: string;
         value?: number;
         payload?: UncertainData;
-    }[]
+    }[];
 }
 
 function UncertaintyChart(props: Props) {

--- a/app/views/Dashboard/Country/index.tsx
+++ b/app/views/Dashboard/Country/index.tsx
@@ -7,6 +7,7 @@ import {
     unique,
     compareDate,
     isDefined,
+    compareNumber,
 } from '@togglecorp/fujs';
 import {
     LineChart,
@@ -346,7 +347,9 @@ function Country(props: Props) {
             };
 
             return valueToReturn;
-        });
+        }).sort(
+            (a, b) => compareNumber(b.contextIndicatorValue, a.contextIndicatorValue),
+        );
         return cases;
     }, [
         countryResponse?.contextualData,
@@ -442,7 +445,7 @@ function Country(props: Props) {
                     (group, key) => group.reduce(
                         (acc, item) => ({
                             ...acc,
-                            [emergency.emergency]: item.contextIndicatorValue,
+                            [emergency.emergency]: Number(item.contextIndicatorValue),
                             date: item.contextDate,
                         }), { date: key },
                     ),

--- a/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
@@ -150,7 +150,7 @@ function MapModal(props: ModalProps) {
                     (group, key) => group.reduce(
                         (acc, item) => ({
                             ...acc,
-                            [emergency.emergency]: item.contextIndicatorValue,
+                            [emergency.emergency]: Number(item.contextIndicatorValue),
                             date: item.contextDate,
                         }), { date: key },
                     ),

--- a/app/views/Dashboard/Overview/PercentageCardGroup/index.tsx
+++ b/app/views/Dashboard/Overview/PercentageCardGroup/index.tsx
@@ -46,7 +46,7 @@ interface LegendProps {
         value: string;
         type?: string;
         id?: string
-    }[]
+    }[];
 }
 
 const normalizedTickFormatter = (d: number) => normalFormatter().format(d);

--- a/app/views/Dashboard/Overview/PercentageCardGroup/index.tsx
+++ b/app/views/Dashboard/Overview/PercentageCardGroup/index.tsx
@@ -310,6 +310,7 @@ function PercentageCardGroup(props: Props) {
                     minimumValue: negativeRange,
                     maximumValue: positiveRange,
                     indicatorName: global.indicatorName,
+                    id: global.id,
                 };
             }
 
@@ -324,6 +325,7 @@ function PercentageCardGroup(props: Props) {
                 minimumValue: negativeRange,
                 maximumValue: positiveRange,
                 indicatorName: global.indicatorName,
+                id: global.id,
             };
         }).sort((a, b) => compareDate(a.date, b.date))
     ), [
@@ -350,6 +352,7 @@ function PercentageCardGroup(props: Props) {
                     maximumValue: positiveRange,
                     region: region.region,
                     indicatorName: region.indicatorName,
+                    id: region.id,
                 };
             }
 
@@ -365,6 +368,7 @@ function PercentageCardGroup(props: Props) {
                 maximumValue: positiveRange,
                 region: region.region,
                 indicatorName: region.indicatorName,
+                id: region.id,
             };
         }).sort((a, b) => compareDate(a.date, b.date))
     ), [overviewStatsResponse?.uncertaintyRegion]);


### PR DESCRIPTION
- Addresses #195 #165 #196 

## Changes
- Fix line hidden in country modal and country page
- Fix ordering of outbreak box in country page

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
