### PR TITLE
Fix bugs for country scorecard and filters

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,7 +5,7 @@
         <meta charset="utf-8" />
         <style>
             :root {
-                --font-family-sans-serif: 'PT Sans', sans-serif;
+                --font-family-sans-serif: 'Open Sans', sans-serif;
                 --font-family-monospace: 'Inconsolata', monospace;
                 --color-background: #fff;
                 --color-text: rgba(0, 0, 0, .7);
@@ -58,6 +58,6 @@
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         -->
-        <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;700&family=PT+Sans:wght@400;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&family=PT+Sans:wght@400;700&display=swap" rel="stylesheet">
     </body>
 </html>

--- a/app/views/Dashboard/Country/index.tsx
+++ b/app/views/Dashboard/Country/index.tsx
@@ -771,7 +771,10 @@ function Country(props: Props) {
                 <div className={styles.countryDetailWrapper}>
                     <ContainerCard
                         className={styles.statusCardContainer}
-                        contentClassName={styles.statusContainer}
+                        contentClassName={_cs(
+                            styles.statusContainer,
+                            countryWiseOutbreakCases.length > 1 && styles.wrapReversed,
+                        )}
                     >
                         {countryWiseOutbreakCases.length > 0 && (
                             <ListView
@@ -785,16 +788,29 @@ function Country(props: Props) {
                                 pending={false}
                             />
                         )}
-                        <ListView
-                            className={styles.readinessListCard}
-                            renderer={ScoreCard}
-                            rendererParams={readinessRendererParams}
-                            data={scoreCardData}
-                            keySelector={readinessKeySelector}
-                            errored={false}
-                            filtered={false}
-                            pending={false}
-                        />
+                        <div className={styles.scoreCard}>
+                            <span className={styles.scoreHeading}>
+                                Global Health Security Index
+                            </span>
+                            <ListView
+                                className={styles.readinessListCard}
+                                renderer={ScoreCard}
+                                rendererParams={readinessRendererParams}
+                                data={scoreCardData}
+                                keySelector={readinessKeySelector}
+                                errored={false}
+                                filtered={false}
+                                pending={false}
+                            />
+                            <span className={styles.scoreFooter}>
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                                Nam posuere lorem nec elementum dapibus.
+                                Maecenas eu massa at sapien semper pharetra.
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                                Nam posuere lorem nec elementum dapibus.
+                                Maecenas eu massa at sapien semper pharetra.
+                            </span>
+                        </div>
                     </ContainerCard>
                     {filterValues?.indicator ? (
                         <div className={styles.indicatorWrapper}>

--- a/app/views/Dashboard/Country/styles.css
+++ b/app/views/Dashboard/Country/styles.css
@@ -26,23 +26,42 @@
 
                 .status-container {
                     display: flex;
-                    flex-wrap: wrap-reverse;
                     gap: var(--dui-spacing-large);
+
+                    &.wrap-reversed {
+                        flex-wrap: wrap-reverse;
+                    }
 
                     .info-cards {
                         display: flex;
+                        flex-shrink: 0;
                         flex-wrap: wrap-reverse;
                         gap: var(--dui-spacing-large);
                     }
 
-                    .readiness-list-card {
+                    .score-card {
                         display: flex;
+                        flex-direction: column;
                         flex-grow: 1;
-                        flex-wrap: wrap;
                         box-shadow: 0px 0px 10px var(--dui-card-box-shadow);
                         background-color: var(--dui-color-foreground);
                         padding: var(--dui-spacing-medium);
-                        gap: var(--dui-spacing-medium);
+                        gap: var(--dui-spacing-large);
+
+                        .score-heading {
+                            flex-shrink: 0;
+                            font-size: var(--dui-font-size-large);
+                        }
+                        .score-footer {
+                            flex-shrink: 0;
+                            font-size: var(--dui-font-size-medium);
+                            overflow-wrap: break-word;
+                        }
+                        .readiness-list-card {
+                            display: flex;
+                            flex-wrap: wrap;
+                            gap: var(--dui-spacing-medium);
+                        }
                     }
                 }
             }

--- a/app/views/Dashboard/Filters/index.tsx
+++ b/app/views/Dashboard/Filters/index.tsx
@@ -212,6 +212,16 @@ function Filters(props: Props) {
         return doesObjectHaveNoData(value, ['']);
     }, [value, activeTab]);
 
+    const regionFilteredCountries = useMemo(() => (
+        (value?.region && activeTab === 'combinedIndicators')
+            ? countries.filter((country) => country.region === value?.region)
+            : countries
+    ), [
+        countries,
+        value?.region,
+        activeTab,
+    ]);
+
     return (
         <div className={styles.filtersWrapper}>
             <div className={styles.filters}>
@@ -256,7 +266,7 @@ function Filters(props: Props) {
                 {(activeTab === 'combinedIndicators') && (
                     <SelectInput
                         name="country"
-                        options={countries}
+                        options={regionFilteredCountries}
                         placeholder="Country"
                         keySelector={countriesKeySelector}
                         labelSelector={countriesLabelSelector}

--- a/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
@@ -223,7 +223,10 @@ function MapModal(props: ModalProps) {
 
     const handleModalCountryNameClick = useCallback(() => {
         setActiveTab('country');
-        setFilterValues({ country: countryData?.properties?.iso3 });
+        setFilterValues((old) => ({
+            ...old,
+            country: countryData?.properties?.iso3,
+        }));
     }, [
         countryData,
         setActiveTab,

--- a/app/views/Dashboard/Overview/MapView/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '@togglecorp/fujs';
 import {
     Heading,
+    PendingMessage,
     ContainerCard,
     ListView,
     useModalState,
@@ -244,6 +245,7 @@ function MapView(props: MapViewProps) {
 
     const {
         data: overviewMapData,
+        loading: mapDataLoading,
     } = useQuery<MapDataQuery, MapDataQueryVariables>(
         MAP_DATA,
         {
@@ -386,6 +388,7 @@ function MapView(props: MapViewProps) {
     return (
         <div className={_cs(className, styles.mapViewWrapper)}>
             <ContainerCard className={styles.mapContainer}>
+                {mapDataLoading && <PendingMessage />}
                 <Map
                     mapStyle={lightStyle}
                     mapOptions={{


### PR DESCRIPTION
- Addresses 
  - #296
  - #237 
  - #224 
  - #227
 
## Changes

* persist filter while clicking on country name on map modal
* filter country list on filter options based on selected region
* Add heading and footer for country score card

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
