### PR TITLE
Add outbreak name for tooltip

### DIFF
--- a/app/views/Dashboard/Overview/MapView/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/index.tsx
@@ -102,14 +102,6 @@ type BottomCountryType = NonNullable<TopBottomCountriesRankingQuery['bottomCount
 
 const countriesRankingKeySelector = (d: TopCountryType | BottomCountryType) => d.countryId;
 
-interface MapViewProps {
-    className?: string;
-    setActiveTab: React.Dispatch<React.SetStateAction<TabTypes | undefined>>;
-    filterValues?: FilterType | undefined;
-    setFilterValues: React.Dispatch<React.SetStateAction<FilterType | undefined>>;
-    selectedIndicatorName: string | undefined;
-}
-
 interface GeoJsonProps {
     id: number;
     // eslint-disable-next-line camelcase
@@ -206,7 +198,15 @@ function Tooltip(props: TooltipProps) {
     );
 }
 
-function MapView(props: MapViewProps) {
+interface Props{
+    className?: string;
+    setActiveTab: React.Dispatch<React.SetStateAction<TabTypes | undefined>>;
+    filterValues?: FilterType | undefined;
+    setFilterValues: React.Dispatch<React.SetStateAction<FilterType | undefined>>;
+    selectedIndicatorName: string | undefined;
+}
+
+function MapView(props: Props) {
     const {
         className,
         setActiveTab,

--- a/app/views/Dashboard/Overview/MapView/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/index.tsx
@@ -127,6 +127,7 @@ interface TooltipProps {
     indicatorName: string | undefined;
     onHide: () => void;
     lngLat: mapboxgl.LngLatLike;
+    filterValues?: FilterType | undefined;
 }
 
 const lightStyle = 'mapbox://styles/mapbox/light-v10';
@@ -169,6 +170,7 @@ function Tooltip(props: TooltipProps) {
         onHide,
         indicatorData,
         indicatorName,
+        filterValues,
     } = props;
 
     return (
@@ -188,7 +190,7 @@ function Tooltip(props: TooltipProps) {
                         <div className={styles.description}>
                             {isDefined(indicatorName)
                                 ? indicatorName
-                                : 'New cases per million for COVID-19'}
+                                : `New cases per million for ${filterValues?.outbreak ?? 'outbreak'}`}
                         </div>
                     </>
                 )}
@@ -446,6 +448,7 @@ function MapView(props: MapViewProps) {
                                 indicatorName={selectedIndicatorName}
                                 onHide={handleHoverClose}
                                 lngLat={mapClickProperties.lngLat}
+                                filterValues={filterValues}
                             />
                         )}
                 </Map>

--- a/app/views/Dashboard/Overview/PercentageCardGroup/index.tsx
+++ b/app/views/Dashboard/Overview/PercentageCardGroup/index.tsx
@@ -649,7 +649,7 @@ function PercentageCardGroup(props: Props) {
                 heading={filterValues?.indicator ? 'Regional Percentage' : 'Regional Breakdown'}
                 headingSize="extraSmall"
                 headerDescription={filterValues?.indicator
-                    ? `Number of cases for ${selectedIndicatorName}`
+                    ? `${selectedIndicatorName ?? '-'}`
                     : `Number of cases for ${selectedOutbreakName}`}
             >
                 {(filterValues?.indicator)

--- a/app/views/Dashboard/Overview/index.tsx
+++ b/app/views/Dashboard/Overview/index.tsx
@@ -132,6 +132,7 @@ function Overview(props: Props) {
                                 setActiveTab={setActiveTab}
                                 setFilterValues={setFilterValues}
                                 selectedIndicatorName={selectedIndicatorName ?? undefined}
+                                selectedOutbreakName={selectedOutbreakName}
                             />
                         </TabPanel>
                         <TabPanel name="tableMode">

--- a/app/views/Dashboard/Overview/index.tsx
+++ b/app/views/Dashboard/Overview/index.tsx
@@ -132,7 +132,6 @@ function Overview(props: Props) {
                                 setActiveTab={setActiveTab}
                                 setFilterValues={setFilterValues}
                                 selectedIndicatorName={selectedIndicatorName ?? undefined}
-                                selectedOutbreakName={selectedOutbreakName}
                             />
                         </TabPanel>
                         <TabPanel name="tableMode">


### PR DESCRIPTION
## Changes:
- Add outbreak name for tooltip conditionally and also remove "number of cases" from different chart components

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
