### PR TITLE
Fix charts height in firefox

### DIFF
--- a/app/components/ScoreCard/index.tsx
+++ b/app/components/ScoreCard/index.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import { _cs } from '@togglecorp/fujs';
 
+import {
+    Tooltip,
+} from '@the-deep/deep-ui';
+
 import styles from './styles.css';
 
 interface Props {
     className?: string;
     title: string;
     value?: number;
+    date?: string;
+    source?: string;
     indicator?: 'red' | 'yellow' | 'orange' | 'green';
 }
 
@@ -15,6 +21,8 @@ function ScoreCard(props: Props) {
         className,
         title,
         value,
+        date,
+        source,
         indicator,
     } = props;
 
@@ -36,6 +44,13 @@ function ScoreCard(props: Props) {
             >
                 {(value ? `${Math.round(value)}%` : 'N/A')}
             </div>
+
+            {(date || source) && (
+                <Tooltip trackMousePosition>
+                    {source && `${source}`}
+                    {date && ` - ${date}`}
+                </Tooltip>
+            )}
         </div>
     );
 }

--- a/app/views/Dashboard/Country/index.tsx
+++ b/app/views/Dashboard/Country/index.tsx
@@ -59,6 +59,8 @@ import styles from './styles.css';
 interface ScoreCardProps {
     title: string;
     value?: number;
+    date?: string;
+    source?: string;
     indicator?: 'red' | 'yellow' | 'orange' | 'green';
 }
 interface CountryWiseOutbreakCases {
@@ -110,9 +112,17 @@ const COUNTRY_PROFILE = gql`
             populationSize
             region
             readiness
+            readinessDate
+            readinessSource
             vulnerability
+            vulnerabilityDate
+            vulnerabilitySource
             risk
+            riskDate
+            riskSource
             response
+            responseDate
+            responseSource
             stringency
             stringencyRegion
             stringencyFormat
@@ -723,18 +733,26 @@ function Country(props: Props) {
         {
             title: 'Readiness',
             value: countryResponse?.countryProfile.readiness ?? undefined,
+            date: countryResponse?.countryProfile.readinessDate ?? undefined,
+            source: countryResponse?.countryProfile.readinessSource ?? undefined,
         },
         {
             title: 'Vulnerability',
             value: countryResponse?.countryProfile.vulnerability ?? undefined,
+            date: countryResponse?.countryProfile.vulnerabilityDate ?? undefined,
+            source: countryResponse?.countryProfile.vulnerabilitySource ?? undefined,
         },
         {
             title: 'Risk',
             value: countryResponse?.countryProfile.risk ?? undefined,
+            date: countryResponse?.countryProfile.riskDate ?? undefined,
+            source: countryResponse?.countryProfile.riskSource ?? undefined,
         },
         {
             title: 'Response',
             value: countryResponse?.countryProfile.response ?? undefined,
+            date: countryResponse?.countryProfile.responseDate ?? undefined,
+            source: countryResponse?.countryProfile.responseSource ?? undefined,
         },
     ]), [
         countryResponse?.countryProfile,
@@ -755,6 +773,8 @@ function Country(props: Props) {
     const readinessRendererParams = useCallback((_, data: ScoreCardProps) => ({
         title: data.title,
         value: data.value,
+        date: data.date,
+        source: data.source,
         indicator: metricTypeForColor(data),
     }), []);
 

--- a/app/views/Dashboard/Country/styles.css
+++ b/app/views/Dashboard/Country/styles.css
@@ -19,6 +19,9 @@
             gap: var(--dui-spacing-large);
 
             .status-card-container {
+                display: flex;
+                flex-direction: column;
+                flex-shrink: 0;
                 border-radius: 0;
                 /* By default, ContainerCard has border-radius */
                 background-color: var(--color-background);
@@ -67,14 +70,22 @@
             }
 
             .country-trend {
+                display: flex;
+                flex-direction: column;
+                flex-grow: 1;
                 border-radius: 0;
                 /* By default, ContainerCard has border-radius */
                 box-shadow: 0px 0px 10px var(--dui-card-box-shadow);
 
                 .responsive-content {
+                    display: flex;
+                    flex-direction: column;
+                    flex-grow: 1;
                     min-height: 20rem;
 
                     .responsive-container {
+                        display: flex;
+                        flex-grow: 1;
                         overflow: hidden;
 
                         .tooltip-card {
@@ -161,6 +172,7 @@
         }
 
         .country-info {
+            flex-shrink: 0;
             border-radius: 0;
             /* By default, ContainerCard has border-radius */
             box-shadow: 0px 0px 10px var(--dui-card-box-shadow);

--- a/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
@@ -95,7 +95,7 @@ const COUNTRY_PROFILE = gql`
         contextualData(
             filters: {
                 iso3: $iso3,
-                contextIndicatorId:"total_cases",
+                contextIndicatorId:"new_cases_per_million",
                 emergency: $emergency,
                 isTwelveMonth: true,
             }
@@ -116,6 +116,7 @@ const COUNTRY_PROFILE = gql`
         }
         contextualDataWithMultipleEmergency(
             iso3: $iso3,
+            contextIndicatorId: "new_cases_per_million",
         ) {
             emergency
             data {


### PR DESCRIPTION
- Addresses #225 
- Depends on https://github.com/collective-service/ifrc-gates-backend/pull/177

## Changes

* Fix charts height in firefox
* Add tooltip to country scorecard

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
