### PR TITLE
Change 0 to <1 if value is less than 0.9999

### DIFF
--- a/app/components/CustomTooltip/index.tsx
+++ b/app/components/CustomTooltip/index.tsx
@@ -84,7 +84,6 @@ function CustomTooltip(props: Props) {
                                 isDefined(calculatedTotal) && calculatedTotal !== 0
                                     ? item.contextIndicatorValue / calculatedTotal
                                     : undefined,
-                                false,
                             )})`)}
                         {(isDefined(minValue) && isDefined(maxValue))
                             ? uncertaintyRange

--- a/app/components/CustomTooltip/index.tsx
+++ b/app/components/CustomTooltip/index.tsx
@@ -92,10 +92,7 @@ function CustomTooltip(props: Props) {
         return (
             <div className={styles.tooltipContent}>
                 {isDefined(valueLabel) && `${valueLabel} : `}
-                {(isDefined(value) && value !== null) && formatNumber(
-                    format === 'million' ? 'raw' : format,
-                    value,
-                )}
+                {format === 'raw' ? value : formatNumber(format, value)}
                 {(isDefined(minValue) && isDefined(maxValue))
                     ? uncertaintyRange
                     : null}

--- a/app/components/CustomTooltip/index.tsx
+++ b/app/components/CustomTooltip/index.tsx
@@ -57,8 +57,7 @@ function CustomTooltip(props: Props) {
 
     const calculatedTotal = useMemo(() => (
         customTooltipData?.reduce(
-            // FIXME: this might not be correct
-            (acc, obj) => (acc + (obj?.contextIndicatorValue ?? 1)), 0,
+            (acc, obj) => (acc + (obj?.contextIndicatorValue ?? 0)), 0,
         )
     ), [
         customTooltipData,

--- a/app/components/CustomTooltip/index.tsx
+++ b/app/components/CustomTooltip/index.tsx
@@ -57,6 +57,7 @@ function CustomTooltip(props: Props) {
 
     const calculatedTotal = useMemo(() => (
         customTooltipData?.reduce(
+            // FIXME: this might not be correct
             (acc, obj) => (acc + (obj?.contextIndicatorValue ?? 1)), 0,
         )
     ), [
@@ -79,8 +80,9 @@ function CustomTooltip(props: Props) {
                                 item.contextIndicatorValue,
                             )} (${formatNumber(
                                 'percent',
-                                item.contextIndicatorValue,
-                                calculatedTotal,
+                                isDefined(calculatedTotal) && calculatedTotal !== 0
+                                    ? item.contextIndicatorValue / calculatedTotal
+                                    : undefined,
                             )})`)}
                         {(isDefined(minValue) && isDefined(maxValue))
                             ? uncertaintyRange

--- a/app/components/CustomTooltip/index.tsx
+++ b/app/components/CustomTooltip/index.tsx
@@ -48,7 +48,7 @@ function CustomTooltip(props: Props) {
     const uncertaintyRange = useMemo(() => (
         format === 'percent'
             ? `[${negativeToZero(minValue, null)}% - ${positiveToZero(maxValue, null)}%]`
-            : `[${formatNumber(format, minValue)} - ${formatNumber(format, maxValue)}]`
+            : `[${formatNumber(format, minValue, false)} - ${formatNumber(format, maxValue, false)}]`
     ), [
         minValue,
         maxValue,
@@ -78,11 +78,13 @@ function CustomTooltip(props: Props) {
                             && (`${formatNumber(
                                 'raw',
                                 item.contextIndicatorValue,
+                                false,
                             )} (${formatNumber(
                                 'percent',
                                 isDefined(calculatedTotal) && calculatedTotal !== 0
                                     ? item.contextIndicatorValue / calculatedTotal
                                     : undefined,
+                                false,
                             )})`)}
                         {(isDefined(minValue) && isDefined(maxValue))
                             ? uncertaintyRange
@@ -94,7 +96,7 @@ function CustomTooltip(props: Props) {
         return (
             <div className={styles.tooltipContent}>
                 {isDefined(valueLabel) && `${valueLabel} : `}
-                {format === 'raw' ? value : formatNumber(format, value)}
+                {formatNumber(format, value, false)}
                 {(isDefined(minValue) && isDefined(maxValue))
                     ? uncertaintyRange
                     : null}

--- a/app/components/MapLabel/index.tsx
+++ b/app/components/MapLabel/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { _cs } from '@togglecorp/fujs';
 
-import { formatNumber, FormatType, normalizedValue } from '#utils/common';
+import { formatNumber, FormatType } from '#utils/common';
 
 import styles from './styles.css';
 
@@ -25,10 +25,11 @@ function MapLabel(props: Props) {
             <div className={styles.bar} />
             <div className={styles.labelContainer}>
                 <div>
-                    {formatNumber(format, minValue) ?? 'N/a'}
+                    {/* FIXME: handle special case here */}
+                    {formatNumber(format, minValue, false) ?? 'N/a'}
                 </div>
                 <div>
-                    {normalizedValue(maxValue, format) ?? 'N/a'}
+                    {formatNumber(format, maxValue) ?? 'N/a'}
                 </div>
             </div>
         </div>

--- a/app/components/MapLabel/index.tsx
+++ b/app/components/MapLabel/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { _cs } from '@togglecorp/fujs';
 
-import { formatNumber, FormatType } from '#utils/common';
+import { formatNumber, FormatType, normalizedValue } from '#utils/common';
 
 import styles from './styles.css';
 
@@ -28,7 +28,7 @@ function MapLabel(props: Props) {
                     {formatNumber(format, minValue) ?? 'N/a'}
                 </div>
                 <div>
-                    {formatNumber(format, maxValue) ?? 'N/a'}
+                    {normalizedValue(maxValue, format) ?? 'N/a'}
                 </div>
             </div>
         </div>

--- a/app/components/MapLabel/index.tsx
+++ b/app/components/MapLabel/index.tsx
@@ -25,8 +25,7 @@ function MapLabel(props: Props) {
             <div className={styles.bar} />
             <div className={styles.labelContainer}>
                 <div>
-                    {/* FIXME: handle special case here */}
-                    {formatNumber(format, minValue, false) ?? 'N/a'}
+                    {minValue < 1 ? 0 : formatNumber(format, minValue, false) ?? 'N/a'}
                 </div>
                 <div>
                     {formatNumber(format, maxValue) ?? 'N/a'}

--- a/app/components/PercentageStats/index.tsx
+++ b/app/components/PercentageStats/index.tsx
@@ -6,7 +6,10 @@ import {
     Tooltip,
     Message,
 } from '@the-deep/deep-ui';
-import { _cs } from '@togglecorp/fujs';
+import {
+    _cs,
+    isNotDefined,
+} from '@togglecorp/fujs';
 import { IoFileTraySharp } from 'react-icons/io5';
 import { formatNumber, FormatType } from '#utils/common';
 
@@ -52,8 +55,7 @@ function PercentageStats(props: Props) {
         format,
     } = props;
 
-    // FIXME: use isNotDefined
-    const empty = !statValue;
+    const empty = isNotDefined(statValue);
 
     const valueTooltip = (
         (newDeaths || newCasesPerMillion) ? (

--- a/app/components/PercentageStats/index.tsx
+++ b/app/components/PercentageStats/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '@the-deep/deep-ui';
 import { _cs } from '@togglecorp/fujs';
 import { IoFileTraySharp } from 'react-icons/io5';
+import { formatNumber, FormatType } from '#utils/common';
 
 import styles from './styles.css';
 
@@ -18,8 +19,8 @@ export interface Props {
     heading?: React.ReactNode;
     headerDescription?: React.ReactNode;
     headingSize?: headingSizeType;
-    statValue: string | number | undefined;
-    nonNormalizedStatValue?: number | null;
+    statValue: number | undefined | null;
+    format: FormatType;
     subValue?: number;
     newDeaths?: string | null;
     newCasesPerMillion?: string | null;
@@ -41,7 +42,6 @@ function PercentageStats(props: Props) {
         statValue,
         subValue,
         newDeaths,
-        nonNormalizedStatValue,
         newCasesPerMillion,
         totalDeaths,
         newCases,
@@ -49,8 +49,10 @@ function PercentageStats(props: Props) {
         statValueLoading,
         indicatorMonth,
         uncertaintyRange,
+        format,
     } = props;
 
+    // FIXME: use isNotDefined
     const empty = !statValue;
 
     const valueTooltip = (
@@ -78,7 +80,7 @@ function PercentageStats(props: Props) {
         ) : (
             <Tooltip>
                 <div>
-                    {`Total: ${nonNormalizedStatValue ?? statValue ?? 0}`}
+                    {`Total: ${formatNumber(format, statValue, false)}`}
                 </div>
                 <div>
                     {`Date: ${indicatorMonth ?? 'N/a'}`}

--- a/app/components/PercentageStats/index.tsx
+++ b/app/components/PercentageStats/index.tsx
@@ -18,7 +18,8 @@ export interface Props {
     heading?: React.ReactNode;
     headerDescription?: React.ReactNode;
     headingSize?: headingSizeType;
-    statValue: string | undefined;
+    statValue: string | number | undefined;
+    nonNormalizedStatValue?: number | null;
     subValue?: number;
     newDeaths?: string | null;
     newCasesPerMillion?: string | null;
@@ -40,6 +41,7 @@ function PercentageStats(props: Props) {
         statValue,
         subValue,
         newDeaths,
+        nonNormalizedStatValue,
         newCasesPerMillion,
         totalDeaths,
         newCases,
@@ -76,7 +78,7 @@ function PercentageStats(props: Props) {
         ) : (
             <Tooltip>
                 <div>
-                    {`Total: ${statValue ?? 0}`}
+                    {`Total: ${nonNormalizedStatValue ?? statValue ?? 0}`}
                 </div>
                 <div>
                     {`Date: ${indicatorMonth ?? 'N/a'}`}

--- a/app/components/PercentageStats/index.tsx
+++ b/app/components/PercentageStats/index.tsx
@@ -128,7 +128,7 @@ function PercentageStats(props: Props) {
             ) : (
                 <>
                     <div className={styles.valueText}>
-                        {statValue}
+                        {formatNumber(format, statValue, true)}
                     </div>
                     {subValue && (
                         <NumberOutput

--- a/app/components/ProgressBar/index.tsx
+++ b/app/components/ProgressBar/index.tsx
@@ -6,6 +6,7 @@ import {
 import { Tooltip } from '@the-deep/deep-ui';
 import {
     isNotDefined,
+    isDefined,
     _cs,
 } from '@togglecorp/fujs';
 import React, { useMemo } from 'react';
@@ -63,16 +64,26 @@ function ProgressBar(props: Props) {
         if (format === 'percent') {
             return formatNumber('percent', value);
         }
-        if (value < 0.9999) {
+        if (value < 1) {
             return '< 1';
         }
-        return formatNumber(format, value, totalValue ?? 0);
+        return formatNumber(
+            format,
+            isDefined(totalValue) && totalValue !== 0
+                ? (value ?? 0) / totalValue
+                : undefined,
+        );
     }, [value,
         format,
         totalValue,
     ]);
 
-    const totalValueForWidth = formatNumber('percent', value ?? 0, totalValue ?? 0);
+    const totalValueForWidth = formatNumber(
+        'percent',
+        isDefined(totalValue) && totalValue !== 0
+            ? (value ?? 0) / totalValue
+            : undefined,
+    );
 
     return (
         <div className={_cs(className, styles.progressInfo)}>

--- a/app/components/ProgressBar/index.tsx
+++ b/app/components/ProgressBar/index.tsx
@@ -1,11 +1,9 @@
 import {
     formatNumber,
     FormatType,
-    normalCommaFormatter,
 } from '#utils/common';
 import { Tooltip } from '@the-deep/deep-ui';
 import {
-    isNotDefined,
     isDefined,
     _cs,
 } from '@togglecorp/fujs';
@@ -40,50 +38,18 @@ function ProgressBar(props: Props) {
         hideTooltip = false,
     } = props;
 
-    const valueTooltip = useMemo(() => {
-        if (isNotDefined(value)) {
-            return 0;
-        }
+    const actualValue = useMemo(() => {
         if (format === 'percent') {
-            return (`${valueTitle}: ${Math.round((value ?? 0) * 10000) / 100}%` ?? undefined);
-        }
-        if (value < 0.999) {
             return value;
         }
-        return (`${valueTitle}: ${normalCommaFormatter().format(value ?? 0)}`);
+        return isDefined(totalValue) && totalValue !== 0
+            ? (value ?? 0) / totalValue
+            : undefined;
     }, [
         value,
-        valueTitle,
-        format,
-    ]);
-
-    const progressValue = useMemo(() => {
-        if (isNotDefined(value)) {
-            return 0;
-        }
-        if (format === 'percent') {
-            return formatNumber('percent', value);
-        }
-        if (value < 1) {
-            return '< 1';
-        }
-        return formatNumber(
-            format,
-            isDefined(totalValue) && totalValue !== 0
-                ? (value ?? 0) / totalValue
-                : undefined,
-        );
-    }, [value,
         format,
         totalValue,
     ]);
-
-    const totalValueForWidth = formatNumber(
-        'percent',
-        isDefined(totalValue) && totalValue !== 0
-            ? (value ?? 0) / totalValue
-            : undefined,
-    );
 
     return (
         <div className={_cs(className, styles.progressInfo)}>
@@ -99,7 +65,9 @@ function ProgressBar(props: Props) {
                         className={styles.progressBarStyle}
                         key={undefined}
                         style={{
-                            width: totalValueForWidth,
+                            width: isDefined(actualValue)
+                                ? 100 * actualValue
+                                : 0,
                             backgroundColor: color ?? 'blue',
                         }}
                     />
@@ -108,13 +76,14 @@ function ProgressBar(props: Props) {
                     <Tooltip
                         trackMousePosition
                     >
-                        {valueTooltip}
+                        {/* FIXME: pass prop to show decimal here */}
+                        {`${valueTitle}: ${formatNumber(format, actualValue, false)}`}
                     </Tooltip>
                 )}
                 <div
                     className={styles.progressValue}
                 >
-                    {progressValue}
+                    {formatNumber(format, actualValue)}
                 </div>
             </div>
             {footer}

--- a/app/components/ProgressBar/index.tsx
+++ b/app/components/ProgressBar/index.tsx
@@ -40,10 +40,10 @@ function ProgressBar(props: Props) {
 
     const actualValue = useMemo(() => {
         if (format === 'percent') {
-            return value;
+            return isDefined(value) ? value * 100 : undefined;
         }
         return isDefined(totalValue) && totalValue !== 0
-            ? (value ?? 0) / totalValue
+            ? ((value ?? 0) / totalValue) * 100
             : undefined;
     }, [
         value,
@@ -66,7 +66,7 @@ function ProgressBar(props: Props) {
                         key={undefined}
                         style={{
                             width: isDefined(actualValue)
-                                ? 100 * actualValue
+                                ? `${actualValue}%`
                                 : 0,
                             backgroundColor: color ?? 'blue',
                         }}
@@ -77,13 +77,13 @@ function ProgressBar(props: Props) {
                         trackMousePosition
                     >
                         {/* FIXME: pass prop to show decimal here */}
-                        {`${valueTitle}: ${formatNumber(format, actualValue, false)}`}
+                        {`${valueTitle}: ${formatNumber(format, value, false)}`}
                     </Tooltip>
                 )}
                 <div
                     className={styles.progressValue}
                 >
-                    {formatNumber(format, actualValue)}
+                    {formatNumber(format, value)}
                 </div>
             </div>
             {footer}

--- a/app/components/ProgressBar/index.tsx
+++ b/app/components/ProgressBar/index.tsx
@@ -76,7 +76,6 @@ function ProgressBar(props: Props) {
                     <Tooltip
                         trackMousePosition
                     >
-                        {/* FIXME: pass prop to show decimal here */}
                         {`${valueTitle}: ${formatNumber(format, value, false)}`}
                     </Tooltip>
                 )}

--- a/app/components/ProgressBar/index.tsx
+++ b/app/components/ProgressBar/index.tsx
@@ -1,13 +1,14 @@
-import React, { useMemo } from 'react';
-import {
-    _cs,
-} from '@togglecorp/fujs';
-import { Tooltip } from '@the-deep/deep-ui';
 import {
     formatNumber,
     FormatType,
     normalCommaFormatter,
 } from '#utils/common';
+import { Tooltip } from '@the-deep/deep-ui';
+import {
+    isNotDefined,
+    _cs,
+} from '@togglecorp/fujs';
+import React, { useMemo } from 'react';
 
 import styles from './styles.css';
 
@@ -39,14 +40,36 @@ function ProgressBar(props: Props) {
     } = props;
 
     const valueTooltip = useMemo(() => {
+        if (isNotDefined(value)) {
+            return 0;
+        }
         if (format === 'percent') {
             return (`${valueTitle}: ${Math.round((value ?? 0) * 10000) / 100}%` ?? undefined);
+        }
+        if (value < 0.999) {
+            return value;
         }
         return (`${valueTitle}: ${normalCommaFormatter().format(value ?? 0)}`);
     }, [
         value,
         valueTitle,
         format,
+    ]);
+
+    const progressValue = useMemo(() => {
+        if (isNotDefined(value)) {
+            return 0;
+        }
+        if (format === 'percent') {
+            return formatNumber('percent', value);
+        }
+        if (value < 0.9999) {
+            return '< 1';
+        }
+        return formatNumber(format, value, totalValue ?? 0);
+    }, [value,
+        format,
+        totalValue,
     ]);
 
     const totalValueForWidth = formatNumber('percent', value ?? 0, totalValue ?? 0);
@@ -80,9 +103,7 @@ function ProgressBar(props: Props) {
                 <div
                     className={styles.progressValue}
                 >
-                    {format === 'percent'
-                        ? formatNumber('percent', value ?? 0)
-                        : formatNumber(format, value ?? 0, totalValue ?? 0)}
+                    {progressValue}
                 </div>
             </div>
             {footer}

--- a/app/utils/common.test.ts
+++ b/app/utils/common.test.ts
@@ -1,4 +1,5 @@
 import {
+    formatNumber,
     getDashboardLink,
     parseQueryString,
 } from './common';
@@ -13,3 +14,35 @@ test ('parse query string', () => {
         hotReload: 'true',
     });
 });
+
+test ('format number raw abbreviate', () => {
+    expect(formatNumber('raw', 0.9999)).toStrictEqual('<1');
+})
+
+test ('format number million abbreviate', () => {
+    expect(formatNumber('million', 123455)).toStrictEqual('<1M');
+})
+
+test ('format number thousand abbreviate', () => {
+    expect(formatNumber('thousand', 1234)).toStrictEqual('1.2K');
+})
+
+test ('format number percentage abbreviate', () => {
+    expect(formatNumber('percent', 0.0099)).toStrictEqual('<1%');
+})
+
+test ('format number raw nonAbbreviate', () => {
+    expect(formatNumber('raw', 0.011111111, false)).toStrictEqual('0.011111111');
+});
+
+test ('format number thousand nonAbbreviate', () => {
+    expect(formatNumber('thousand', 123, false)).toStrictEqual('0.123K');
+})
+
+test ('format number million nonAbbreviate', () => {
+    expect(formatNumber('million', 12345, false)).toStrictEqual('0.012345M');
+})
+
+test ('format number percent nonAbbreviate', () => {
+    expect(formatNumber('percent', 0.0099, false)).toStrictEqual('0.99%');
+})

--- a/app/utils/common.ts
+++ b/app/utils/common.ts
@@ -187,6 +187,25 @@ export const colors: Record<string, string> = {
     Ebola: '#CCB387',
 };
 
+export const normalizedValue = (
+    value: number | null | undefined,
+    format: FormatType,
+) => {
+    if (isNotDefined(value)) {
+        return 0;
+    }
+    if (format === 'percent') {
+        return formatNumber(format, value);
+    }
+    if (value < 0.999) {
+        return '<1';
+    }
+    return formatNumber(
+        (format ?? 'raw'),
+        value,
+    );
+};
+
 export type Maybe<T> = T | undefined | null;
 
 export function max<T>(

--- a/app/views/Dashboard/CombinedIndicators/TopicCard/OutbreakIndicators/ModifiedProgressBar/index.tsx
+++ b/app/views/Dashboard/CombinedIndicators/TopicCard/OutbreakIndicators/ModifiedProgressBar/index.tsx
@@ -108,7 +108,7 @@ function ModifiedProgressBar(props: Props) {
             )}
             format={format}
             barHeight={8}
-            footer={showRegionalValue && subValuePercentage && (
+            footer={showRegionalValue && (
                 <div className={styles.subValue}>
                     {subValuePercentage}
                 </div>

--- a/app/views/Dashboard/Country/index.tsx
+++ b/app/views/Dashboard/Country/index.tsx
@@ -622,22 +622,27 @@ function Country(props: Props) {
                 totalDeaths: formatNumber(
                     totalDeaths?.format as FormatType,
                     totalDeaths?.indicatorValue,
+                    false,
                 ),
                 newCases: formatNumber(
                     newCases?.format as FormatType,
                     newCases?.indicatorValue,
+                    false,
                 ),
                 newDeaths: formatNumber(
                     newDeaths?.format as FormatType,
                     newDeaths?.indicatorValue,
+                    false,
                 ),
                 newCasesPerMillion: formatNumber(
                     newCasesPerMillion?.format as FormatType,
                     newCasesPerMillion?.indicatorValue,
+                    false,
                 ),
                 newDeathsPerMillion: formatNumber(
                     newDeathsPerMillion?.format as FormatType,
                     newDeathsPerMillion?.indicatorValue,
+                    false,
                 ),
             };
         });
@@ -852,7 +857,8 @@ function Country(props: Props) {
 
     const statusRendererParams = useCallback((_, data: CountryWiseOutbreakCases) => ({
         heading: data.emergency,
-        statValue: formatNumber(data.format ?? 'raw', data.totalCases ?? 0),
+        statValue: data.totalCases,
+        format: data.format ?? 'raw' as const,
         headerDescription: selectedIndicatorType === 'Contextual Indicators'
             ? selectedIndicatorName
             : 'Number of cases',
@@ -918,7 +924,7 @@ function Country(props: Props) {
                                 {`(${item.payload?.date})`}
                             </div>
                             <div className={styles.tooltipContent}>
-                                {formatNumber('raw' as FormatType, item.value ?? 0)}
+                                {formatNumber('raw' as FormatType, item.value ?? 0, false)}
                             </div>
                         </div>
                     ))}

--- a/app/views/Dashboard/Country/index.tsx
+++ b/app/views/Dashboard/Country/index.tsx
@@ -41,10 +41,8 @@ import {
     formatNumber,
     FormatType,
     getShortMonth,
-    negativeToZero,
-    normalFormatter,
-    positiveToZero,
     colors,
+    normalFormatter,
 } from '#utils/common';
 import {
     CountryQuery,
@@ -671,8 +669,12 @@ function Country(props: Props) {
             return undefined;
         }
         const uncertaintyData = countryResponse?.dataCountryLevel.map((country) => {
-            const negativeRange = negativeToZero(country.indicatorValue, country.errorMargin);
-            const positiveRange = positiveToZero(country.indicatorValue, country.errorMargin);
+            const negativeRange = isDefined(country.indicatorValue)
+                ? bound(country.indicatorValue - (country?.errorMargin ?? 0), 0, 1)
+                : 0;
+            const positiveRange = isDefined(country.indicatorValue)
+                ? bound(country.indicatorValue + (country.errorMargin ?? 0), 0, 1)
+                : 0;
 
             if (isNotDefined(country.errorMargin)) {
                 return {
@@ -696,10 +698,9 @@ function Country(props: Props) {
                     : country.indicatorValue,
                 tooltipValue: country.indicatorValue,
                 date: country.indicatorMonth,
-                // FIXME : Solve the issue of negativeToZero and positiveToZero
                 uncertainRange: [
-                    negativeRange ?? 0,
-                    positiveRange ?? 0,
+                    negativeRange,
+                    positiveRange,
                 ],
                 minimumValue: isDefined(country.indicatorValue)
                     ? bound(country.indicatorValue - country.errorMargin, 0, 1)

--- a/app/views/Dashboard/Export/index.tsx
+++ b/app/views/Dashboard/Export/index.tsx
@@ -185,7 +185,7 @@ function Export(props: Props) {
             <DropdownMenu
                 className={className}
                 label={pendingExport
-                    ? `Preparing Export (${formatNumber('percent', progress)})`
+                    ? `Preparing Export (${formatNumber('percent', progress, false)})`
                     : 'Export'}
                 variant="tertiary"
                 icons={<IoDownloadOutline />}

--- a/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
@@ -348,7 +348,6 @@ function MapModal(props: ModalProps) {
                                 item.value,
                                 false,
                             )}
-                            {item.value}
                         </div>
                     </div>
                 ))}

--- a/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
@@ -32,8 +32,6 @@ import {
     getShortMonth,
     normalFormatter,
     colors,
-    negativeToZero,
-    positiveToZero,
     formatNumber,
 } from '#utils/common';
 import { FilterType } from '#views/Dashboard/Filters';
@@ -270,8 +268,12 @@ function MapModal(props: ModalProps) {
 
     const uncertaintyChart: UncertainData[] | undefined = useMemo(() => (
         countryResponse?.dataCountryLevel.map((country) => {
-            const negativeRange = negativeToZero(country.indicatorValue, country.errorMargin);
-            const positiveRange = positiveToZero(country.indicatorValue, country.errorMargin);
+            const negativeRange = isDefined(country.indicatorValue)
+                ? bound(country.indicatorValue - (country.errorMargin ?? 0), 0, 1)
+                : 0;
+            const positiveRange = isDefined(country.indicatorValue)
+                ? bound(country.indicatorValue + (country.errorMargin ?? 0), 0, 1)
+                : 0;
 
             if (isNotDefined(country.errorMargin)) {
                 return {
@@ -295,10 +297,9 @@ function MapModal(props: ModalProps) {
                     : country.indicatorValue,
                 tooltipValue: country.indicatorValue,
                 date: country.indicatorMonth,
-                // FIXME : Solve the issue of negativeToZero and positiveToZero
                 uncertainRange: [
-                    negativeRange ?? 0,
-                    positiveRange ?? 0,
+                    negativeRange,
+                    positiveRange,
                 ],
                 minimumValue: isDefined(country.indicatorValue)
                     ? bound(country.indicatorValue - country.errorMargin, 0, 1)
@@ -342,7 +343,6 @@ function MapModal(props: ModalProps) {
                             </div>
                         )}
                         <div className={styles.tooltipContent}>
-                            {/* FIXME: pass prop to show decimal here */}
                             {formatNumber(
                                 'raw',
                                 item.value,

--- a/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
@@ -28,13 +28,13 @@ import {
 } from 'recharts';
 import {
     decimalToPercentage,
-    formatNumber,
     FormatType,
     getShortMonth,
     normalFormatter,
     colors,
     negativeToZero,
     positiveToZero,
+    normalizedValue,
 } from '#utils/common';
 import { FilterType } from '#views/Dashboard/Filters';
 import {
@@ -342,7 +342,7 @@ function MapModal(props: ModalProps) {
                             </div>
                         )}
                         <div className={styles.tooltipContent}>
-                            {formatNumber('raw', item.value ?? 0)}
+                            {item.value}
                         </div>
                     </div>
                 ))}
@@ -385,9 +385,9 @@ function MapModal(props: ModalProps) {
                         size="extraLarge"
                         className={styles.countryCaseData}
                     >
-                        {formatNumber(
-                            format as FormatType,
+                        {normalizedValue(
                             indicatorValue,
+                            format as FormatType,
                         )}
                     </Heading>
                     <Heading

--- a/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/MapModal/index.tsx
@@ -34,7 +34,7 @@ import {
     colors,
     negativeToZero,
     positiveToZero,
-    normalizedValue,
+    formatNumber,
 } from '#utils/common';
 import { FilterType } from '#views/Dashboard/Filters';
 import {
@@ -342,6 +342,12 @@ function MapModal(props: ModalProps) {
                             </div>
                         )}
                         <div className={styles.tooltipContent}>
+                            {/* FIXME: pass prop to show decimal here */}
+                            {formatNumber(
+                                'raw',
+                                item.value,
+                                false,
+                            )}
                             {item.value}
                         </div>
                     </div>
@@ -385,9 +391,9 @@ function MapModal(props: ModalProps) {
                         size="extraLarge"
                         className={styles.countryCaseData}
                     >
-                        {normalizedValue(
-                            indicatorValue,
+                        {formatNumber(
                             format as FormatType,
+                            indicatorValue,
                         )}
                     </Heading>
                     <Heading

--- a/app/views/Dashboard/Overview/MapView/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/index.tsx
@@ -34,7 +34,10 @@ import {
     TopBottomCountriesRankingQuery,
     TopBottomCountriesRankingQueryVariables,
 } from '#generated/types';
-import { formatNumber, FormatType } from '#utils/common';
+import {
+    FormatType,
+    normalizedValue,
+} from '#utils/common';
 import { TabTypes, IndicatorType } from '#views/Dashboard';
 import { FilterType } from '#views/Dashboard/Filters';
 
@@ -178,9 +181,9 @@ function Tooltip(props: TooltipProps) {
                     </>
                 )}
                 value={
-                    formatNumber(
-                        (indicatorData?.format ?? 'raw') as FormatType,
+                    normalizedValue(
                         indicatorData?.indicatorValue,
+                        (indicatorData?.format ?? 'raw') as FormatType,
                     )
                 }
                 hideLabelColon

--- a/app/views/Dashboard/Overview/MapView/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/index.tsx
@@ -174,17 +174,16 @@ function Tooltip(props: TooltipProps) {
                 label={(
                     <>
                         {countryName}
-                        {/* TODO: Get outbreak from server */}
                         <div className={styles.description}>
                             {indicatorName}
                         </div>
                     </>
                 )}
                 value={
-                    /* FIXME: pass prop to show decimal here */
                     formatNumber(
                         (indicatorData?.format ?? 'raw') as FormatType,
                         indicatorData?.indicatorValue,
+                        true,
                     )
                 }
                 hideLabelColon

--- a/app/views/Dashboard/Overview/MapView/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/index.tsx
@@ -36,7 +36,7 @@ import {
 } from '#generated/types';
 import {
     FormatType,
-    normalizedValue,
+    formatNumber,
 } from '#utils/common';
 import { TabTypes, IndicatorType } from '#views/Dashboard';
 import { FilterType } from '#views/Dashboard/Filters';
@@ -181,9 +181,11 @@ function Tooltip(props: TooltipProps) {
                     </>
                 )}
                 value={
-                    normalizedValue(
-                        indicatorData?.indicatorValue,
+                    /* FIXME: pass prop to show decimal here */
+                    formatNumber(
                         (indicatorData?.format ?? 'raw') as FormatType,
+                        indicatorData?.indicatorValue,
+                        false,
                     )
                 }
                 hideLabelColon

--- a/app/views/Dashboard/Overview/MapView/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/index.tsx
@@ -185,7 +185,6 @@ function Tooltip(props: TooltipProps) {
                     formatNumber(
                         (indicatorData?.format ?? 'raw') as FormatType,
                         indicatorData?.indicatorValue,
-                        false,
                     )
                 }
                 hideLabelColon

--- a/app/views/Dashboard/Overview/OverviewTable/index.tsx
+++ b/app/views/Dashboard/Overview/OverviewTable/index.tsx
@@ -193,7 +193,7 @@ function IndicatorValue(props: IndicatorValueProps) {
                 color: getTextColorForHex(color),
             }}
         >
-            {isDefined(value) ? formatNumber(format, value) : '-'}
+            {isDefined(value) ? formatNumber(format, value, false) : '-'}
         </div>
     );
 }

--- a/app/views/Dashboard/Overview/PercentageCardGroup/index.tsx
+++ b/app/views/Dashboard/Overview/PercentageCardGroup/index.tsx
@@ -44,7 +44,6 @@ import {
     negativeToZero,
     positiveToZero,
     colors,
-    normalizedValue,
 } from '#utils/common';
 import {
     OverviewStatsQuery,
@@ -307,15 +306,6 @@ function PercentageCardGroup(props: Props) {
         selectedIndicatorType,
     } = props;
 
-    const cardSubHeader = useMemo(() => {
-        if (selectedIndicatorName) {
-            return selectedIndicatorName;
-        }
-        return '';
-    }, [
-        selectedIndicatorName,
-    ]);
-
     const overviewStatsVariables = useMemo((): OverviewStatsQueryVariables => ({
         emergency: filterValues?.outbreak,
         indicatorId: filterValues?.indicator ?? 'new_cases_per_million',
@@ -338,29 +328,6 @@ function PercentageCardGroup(props: Props) {
             variables: overviewStatsVariables,
         },
     );
-
-    const regionalBreakdownRegion = useMemo(() => (
-        overviewStatsResponse?.regionalBreakdownRegion.map((region) => (
-            {
-                id: region.id,
-                indicatorValue: region.indicatorValueRegional,
-                normalizedValue: normalizedValue(
-                    region.indicatorValueRegional,
-                    region.format as FormatType,
-                ),
-                indicatorMonth: region.indicatorMonth,
-                region: region.region,
-                format: region.format,
-                fill: isDefined(filterValues?.region)
-                    && (region.region !== filterValues?.region) ? 0.2 : 1,
-                indicatorType: region.type,
-                errorMargin: region.errorMargin,
-            }
-        ))), [
-        overviewStatsResponse?.regionalBreakdownRegion,
-        filterValues?.region,
-    ]);
-
     const globalRegionCardList = useMemo(() => {
         const global = [...(overviewStatsResponse?.globalLevelSubvariables) ?? []].sort(
             (a, b) => compareNumber(b.indicatorValue, a.indicatorValue),
@@ -392,9 +359,9 @@ function PercentageCardGroup(props: Props) {
         overviewStatsResponse?.totalCasesGlobal.map((global) => (
             {
                 ...global,
-                normalizedValue: normalizedValue(
-                    global.indicatorValueGlobal,
+                normalizedValue: formatNumber(
                     global.format as FormatType,
+                    global.indicatorValueGlobal,
                 ),
             }
         ))), [
@@ -403,10 +370,31 @@ function PercentageCardGroup(props: Props) {
 
     const globalTotalCase = totalCasesGlobal?.[0];
 
+    const regionalBreakdownRegion = useMemo(() => (
+        overviewStatsResponse?.regionalBreakdownRegion.map((region) => ({
+            id: region.id,
+            indicatorValue: region.indicatorValueRegional,
+            normalizedValue: formatNumber(
+                region.format as FormatType,
+                region.indicatorValueRegional,
+            ),
+            indicatorMonth: region.indicatorMonth,
+            region: region.region,
+            format: region.format,
+            fill: isDefined(filterValues?.region)
+                && (region.region !== filterValues?.region) ? 0.2 : 1,
+            indicatorType: region.type,
+            errorMargin: region.errorMargin,
+        }))
+    ), [
+        overviewStatsResponse?.regionalBreakdownRegion,
+        filterValues?.region,
+    ]);
+
     const regionTotalCase = useMemo(() => (
-        regionalBreakdownRegion?.find(
-            (total) => total.region === filterValues?.region,
-        )
+        regionalBreakdownRegion?.find((total) => (
+            total.region === filterValues?.region
+        ))
     ), [
         regionalBreakdownRegion,
         filterValues?.region,
@@ -437,48 +425,21 @@ function PercentageCardGroup(props: Props) {
         regionTotalCase?.format,
     ]);
 
-    const outbreakSubHeader = useMemo(() => {
-        if (selectedIndicatorName) {
-            return `Trend chart for ${selectedIndicatorName ?? filterValues?.indicator}`;
-        }
-        return `New cases per million for ${selectedOutbreakName}`;
-    }, [filterValues?.indicator,
-        selectedIndicatorName,
-        selectedOutbreakName,
-    ]);
+    const outbreakSubHeader = selectedIndicatorName
+        ? `Trend chart for ${selectedIndicatorName ?? filterValues?.indicator}`
+        : `New cases per million for ${selectedOutbreakName}`;
 
-    const totalCaseValue = useMemo(() => {
-        if (filterValues?.region) {
-            return regionTotalCase?.normalizedValue;
-        }
-        return globalTotalCase?.normalizedValue;
-    }, [
-        regionTotalCase,
-        globalTotalCase,
-        filterValues?.region,
-    ]);
+    const totalCaseValue = filterValues?.region
+        ? regionTotalCase?.indicatorValue
+        : globalTotalCase?.indicatorValueGlobal;
 
-    const nonNormalizedTotalCaseValue = useMemo(() => {
-        if (filterValues?.region) {
-            return regionTotalCase?.indicatorValue;
-        }
-        return globalTotalCase?.indicatorValueGlobal;
-    }, [
-        globalTotalCase,
-        regionTotalCase,
-        filterValues?.region,
-    ]);
+    const totalCaseFormat = filterValues?.region
+        ? (regionTotalCase?.format as FormatType | undefined)
+        : (globalTotalCase?.format as FormatType | undefined);
 
-    const percentageCardMonth = useMemo(() => {
-        if (filterValues?.region) {
-            return regionTotalCase?.indicatorMonth;
-        }
-        return globalTotalCase?.indicatorMonth;
-    }, [
-        regionTotalCase,
-        globalTotalCase,
-        filterValues?.region,
-    ]);
+    const percentageCardMonth = filterValues?.region
+        ? regionTotalCase?.indicatorMonth
+        : globalTotalCase?.indicatorMonth;
 
     const uncertaintyRange = useMemo(() => {
         if (filterValues?.indicator
@@ -758,23 +719,21 @@ function PercentageCardGroup(props: Props) {
         selectedIndicatorName,
     ]);
 
-    function StatValueTooltip() {
-        return (
-            <Tooltip>
+    const tooltip = (
+        <Tooltip>
+            <div>
+                {`Total: ${formatNumber(totalCaseFormat ?? 'raw' as const, totalCaseValue, false)}`}
+            </div>
+            <div>
+                {`Date: ${percentageCardMonth ?? 'N/a'}`}
+            </div>
+            {uncertaintyRange && (
                 <div>
-                    {`Total: ${totalCaseValue ?? 0}`}
+                    {`Uncertainty Range: ${uncertaintyRange}`}
                 </div>
-                <div>
-                    {`Date: ${percentageCardMonth ?? 'N/a'}`}
-                </div>
-                {uncertaintyRange && (
-                    <div>
-                        {`Uncertainty Range: ${uncertaintyRange}`}
-                    </div>
-                )}
-            </Tooltip>
-        );
-    }
+            )}
+        </Tooltip>
+    );
 
     return (
         <div className={_cs(className, styles.cardInfo)}>
@@ -784,10 +743,10 @@ function PercentageCardGroup(props: Props) {
                     <PercentageStats
                         className={styles.globalStatCard}
                         heading={cardHeader}
-                        headerDescription={cardSubHeader}
+                        headerDescription={selectedIndicatorName ?? ''}
                         headingSize="extraSmall"
                         statValue={totalCaseValue}
-                        nonNormalizedStatValue={nonNormalizedTotalCaseValue}
+                        format={totalCaseFormat ?? 'raw' as const}
                         statValueLoading={loading}
                         indicatorMonth={percentageCardMonth}
                         uncertaintyRange={uncertaintyRange}
@@ -801,7 +760,7 @@ function PercentageCardGroup(props: Props) {
                             <div className={styles.outbreakCard}>
                                 Global
                             </div>
-                            {StatValueTooltip()}
+                            {tooltip}
                         </>
                     )}
                     headingSize="extraSmall"
@@ -810,7 +769,7 @@ function PercentageCardGroup(props: Props) {
                             <div className={styles.outbreakCard}>
                                 {`${headingDescription} - ${filterValues?.subvariable}`}
                             </div>
-                            {StatValueTooltip()}
+                            {tooltip}
                         </>
                     )}
                     contentClassName={styles.globalDetails}
@@ -829,7 +788,7 @@ function PercentageCardGroup(props: Props) {
                                             selectedGlobalRegion?.indicatorValue,
                                         )
                                         : 'N/a'}
-                                    {StatValueTooltip()}
+                                    {tooltip}
                                 </>
                             </div>
                             <ListView

--- a/app/views/Dashboard/Overview/RegionalBreakdownCard/index.tsx
+++ b/app/views/Dashboard/Overview/RegionalBreakdownCard/index.tsx
@@ -27,7 +27,7 @@ import {
 import {
     FormatType,
     colors,
-    normalizedValue,
+    formatNumber,
 } from '#utils/common';
 import ChartContainer from '#components/ChartContainer';
 import CustomTooltip from '#components/CustomTooltip';
@@ -233,9 +233,9 @@ function RegionalBreakdownCard(props: Props) {
         {
             ...total,
             indicatorValue: total.indicatorValueGlobal,
-            normalizedValue: normalizedValue(
-                total.indicatorValueGlobal,
+            indicatorFormattedValue: formatNumber(
                 total.format as FormatType,
+                total.indicatorValueGlobal,
             ),
             fill: colors[total.emergency],
         }
@@ -245,9 +245,9 @@ function RegionalBreakdownCard(props: Props) {
         {
             ...region,
             indicatorValue: region.indicatorValueRegional,
-            normalizedValue: normalizedValue(
-                region.indicatorValueRegional,
+            indicatorFormattedValue: formatNumber(
                 region.format as FormatType,
+                region.indicatorValueRegional,
             ),
             fill: colors[region.emergency],
         }
@@ -331,7 +331,7 @@ function RegionalBreakdownCard(props: Props) {
                                 />
                             ))}
                             <LabelList
-                                dataKey="normalizedValue"
+                                dataKey="indicatorFormattedValue"
                                 position="insideBottomLeft"
                                 angle={270}
                                 offset={-2.8}

--- a/app/views/Dashboard/Overview/RegionalBreakdownCard/index.tsx
+++ b/app/views/Dashboard/Overview/RegionalBreakdownCard/index.tsx
@@ -25,9 +25,9 @@ import {
     RegionalAndTotalQueryVariables,
 } from '#generated/types';
 import {
-    formatNumber,
     FormatType,
     colors,
+    normalizedValue,
 } from '#utils/common';
 import ChartContainer from '#components/ChartContainer';
 import CustomTooltip from '#components/CustomTooltip';
@@ -159,7 +159,6 @@ function CustomTotalTooltip(tooltipProps: TooltipProps) {
                 heading={label}
                 subHeading={`(${totalCases[0].payload?.indicatorMonth})`}
                 value={totalCases[0].payload?.indicatorValue}
-
             />
         );
     }
@@ -234,9 +233,9 @@ function RegionalBreakdownCard(props: Props) {
         {
             ...total,
             indicatorValue: total.indicatorValueGlobal,
-            normalizedValue: formatNumber(
-                (total?.format ?? 'raw') as FormatType,
-                total?.indicatorValueGlobal ?? 0,
+            normalizedValue: normalizedValue(
+                total.indicatorValueGlobal,
+                total.format as FormatType,
             ),
             fill: colors[total.emergency],
         }
@@ -246,9 +245,9 @@ function RegionalBreakdownCard(props: Props) {
         {
             ...region,
             indicatorValue: region.indicatorValueRegional,
-            normalizedValue: formatNumber(
-                (region.format ?? 'raw') as FormatType,
-                region.indicatorValueRegional ?? 0,
+            normalizedValue: normalizedValue(
+                region.indicatorValueRegional,
+                region.format as FormatType,
             ),
             fill: colors[region.emergency],
         }


### PR DESCRIPTION
- Addresses 
- #449
- #450  

Depends on:  fix/redis-key-generator

## Changes

* Change 0 to <1 in bar label list and pass nonNormalizedValue in regional Breakdown chart
* Change 0 to <1 in progress bar and change value in tooltip

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
