### PR TITLE
Fixes for tool-tips and loader element

### DIFF
--- a/app/components/PercentageStats/index.tsx
+++ b/app/components/PercentageStats/index.tsx
@@ -61,19 +61,22 @@ function PercentageStats(props: Props) {
         (newDeaths || newCasesPerMillion) ? (
             <Tooltip>
                 <div>
-                    {`New Cases: ${newCases ?? 0}`}
+                    {`Total Cases: ${statValue ?? 'N/a'}`}
                 </div>
                 <div>
-                    {`New Deaths: ${newDeaths ?? 0}`}
+                    {`New Cases: ${newCases ?? 'N/a'}`}
                 </div>
                 <div>
-                    {`Total Deaths: ${totalDeaths ?? 0}`}
+                    {`New Deaths: ${newDeaths ?? 'N/a'}`}
                 </div>
                 <div>
-                    {`Cases Per Million: ${newCasesPerMillion ?? 0}`}
+                    {`Total Deaths: ${totalDeaths ?? 'N/a'}`}
                 </div>
                 <div>
-                    {`Deaths Per Million: ${newDeathsPerMillion ?? 0}`}
+                    {`Cases Per Million: ${newCasesPerMillion ?? 'N/a'}`}
+                </div>
+                <div>
+                    {`Deaths Per Million: ${newDeathsPerMillion ?? 'N/a'}`}
                 </div>
                 <div>
                     {`Date: ${indicatorMonth ?? 'N/a'}`}
@@ -119,29 +122,33 @@ function PercentageStats(props: Props) {
             )}
             headerIconsContainerClassName={styles.iconContainer}
             headerIcons={icon}
-            footerContentClassName={empty ? styles.message : styles.valueAndSubValue}
-            footerContent={(empty ? (
+            footerContentClassName={styles.valueAndSubValue}
+            footerContent={(!empty && (
+                <>
+                    <div className={styles.valueText}>
+                        {formatNumber(format, statValue, true)}
+                    </div>
+                    {
+                        subValue && (
+                            <NumberOutput
+                                className={styles.subValueText}
+                                value={subValue}
+                            />
+                        )
+                    }
+                    {valueTooltip}
+                </>
+            ))}
+        >
+            {empty && (
                 <Message
                     empty={empty}
                     emptyIcon={<IoFileTraySharp />}
                     pending={statValueLoading}
                     pendingContainerClassName={styles.pendingMessage}
                 />
-            ) : (
-                <>
-                    <div className={styles.valueText}>
-                        {formatNumber(format, statValue, true)}
-                    </div>
-                    {subValue && (
-                        <NumberOutput
-                            className={styles.subValueText}
-                            value={subValue}
-                        />
-                    )}
-                    {valueTooltip}
-                </>
-            ))}
-        />
+            )}
+        </ContainerCard>
     );
 }
 export default PercentageStats;

--- a/app/components/PercentageStats/styles.css
+++ b/app/components/PercentageStats/styles.css
@@ -48,18 +48,10 @@
         flex-wrap: wrap;
     }
 
-    .message {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        height: 100%;
-    }
-
     .pending-message {
         display: flex;
         align-items: center;
         flex-direction: column;
         justify-content: center;
-        height: 100%;
     }
 }

--- a/app/components/ProgressBar/index.tsx
+++ b/app/components/ProgressBar/index.tsx
@@ -15,7 +15,7 @@ export interface Props {
     className?: string | undefined;
     barHeight?: number;
     barName: React.ReactNode | undefined;
-    valueTitle?: string | undefined;
+    emergency?: string | undefined;
     color?: string;
     value: number | null | undefined;
     totalValue: number | null | undefined;
@@ -29,9 +29,9 @@ function ProgressBar(props: Props) {
         className,
         barHeight = 8,
         barName,
-        valueTitle,
         color,
         value,
+        emergency,
         totalValue,
         format,
         footer,
@@ -76,7 +76,7 @@ function ProgressBar(props: Props) {
                     <Tooltip
                         trackMousePosition
                     >
-                        {`${valueTitle}: ${formatNumber(format, value, false)}`}
+                        {`${emergency ?? 'N/a'}: ${value ? formatNumber(format, value, false) : 'N/a'}`}
                     </Tooltip>
                 )}
                 <div

--- a/app/views/Dashboard/CombinedIndicators/TopicCard/OutbreakIndicators/index.tsx
+++ b/app/views/Dashboard/CombinedIndicators/TopicCard/OutbreakIndicators/index.tsx
@@ -64,7 +64,6 @@ function OutbreakIndicators(props: Props) {
             indicatorMonth: data.indicatorMonth ?? undefined,
             title: data.indicatorDescription ?? undefined,
             country,
-            valueTitle: data.indicatorName ?? undefined,
             value: data.indicatorValue ?? undefined,
             totalValue: 1,
             indicatorId: data.indicatorId ?? undefined,

--- a/app/views/Dashboard/Country/index.tsx
+++ b/app/views/Dashboard/Country/index.tsx
@@ -137,6 +137,7 @@ const COUNTRY_PROFILE = gql`
             stringencyRegion
             stringencyFormat
             stringencyDate
+            totalCases
             economicSupportIndex
             economicSupportIndexRegion
             economicSupportIndexDate

--- a/app/views/Dashboard/Overview/MapView/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/index.tsx
@@ -91,6 +91,7 @@ const TOP_BOTTOM_COUNTRIES_RANKING = gql`
             format
             indicatorValue
             iso3
+            emergency
         }
         bottomCountriesRanking: overviewRanking(
             emergency: $emergency,
@@ -104,6 +105,7 @@ const TOP_BOTTOM_COUNTRIES_RANKING = gql`
             format
             indicatorValue
             iso3
+            emergency
         }
     }
 `;
@@ -426,8 +428,8 @@ function MapView(props: Props) {
             barHeight,
             barName: data.countryName,
             title: data.countryName,
-            valueTitle: data.countryName,
             value: data.indicatorValue,
+            emergency: data.emergency,
             totalValue: highestTopRankingValue,
             color: '#98A6B5',
             format: data.format as FormatType,
@@ -498,7 +500,7 @@ function MapView(props: Props) {
                     mapOptions={{
                         logoPosition: 'bottom-left',
                         zoom: 1,
-                        minZoom: 0,
+                        minZoom: 0.8,
                         maxZoom: 3.5,
                     }}
                     scaleControlShown

--- a/app/views/Dashboard/Overview/MapView/styles.css
+++ b/app/views/Dashboard/Overview/MapView/styles.css
@@ -26,10 +26,12 @@
 
         .low-progress-box {
             padding-top: var(--dui-spacing-large);
+            min-height: 21rem;
         }
 
         .high-progress-box {
             padding-top: none;
+            min-height: 21rem;
         }
 
         .pending-message {

--- a/app/views/Dashboard/Overview/RegionalBreakdownCard/PieChartInfo/index.tsx
+++ b/app/views/Dashboard/Overview/RegionalBreakdownCard/PieChartInfo/index.tsx
@@ -111,6 +111,10 @@ function PieChartInfo(props: Props) {
                                 x: false,
                                 y: false,
                             }}
+                            position={{
+                                x: 0,
+                                y: -15,
+                            }}
                             content={customPieChartTooltip}
                         />
                     </PieChart>


### PR DESCRIPTION
## Addresses:
- Issue: https://github.com/collective-service/ifrc-gates-dashboard/issues/483#issue-1516051362
- Issue: https://github.com/collective-service/ifrc-gates-dashboard/issues/389#issue-1462780206
- Issue: https://github.com/collective-service/ifrc-gates-dashboard/issues/387#issue-1462753673

## Changes
- Fixes for pie chart tool-tip which escapes the view box making data un-readable
- Fixes for outbreak data not visible in the top/bottom ranking progress bar tool-tips
- Fixes for Total cases not visible in PercentageCard of country section
- Fixes for loader component  not appearing in the center of percentage card of overview section 
- Fixes for centering the loader elements of Top/Bottom ranking
- Fixes for zoom buttons of mapbox

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
