### PR TITLE
Add fixes to region bounds for mapbox

### DIFF
--- a/app/utils/regionBounds.ts
+++ b/app/utils/regionBounds.ts
@@ -28,7 +28,7 @@ export const regionBounds: Bounds[] = [
         boundingBox: [
             -117,
             53.5585,
-            34.10764,
+            36.10764,
             -54.77829,
         ],
     },

--- a/app/views/Dashboard/Overview/MapView/index.tsx
+++ b/app/views/Dashboard/Overview/MapView/index.tsx
@@ -257,6 +257,12 @@ function MapView(props: Props) {
         setCountryData,
     ] = useState<{ iso3: string, name: string } | undefined>();
 
+    useEffect(() => {
+        if (regionId) {
+            setCountryCode(undefined);
+        }
+    }, [regionId]);
+
     const mapVariables = useMemo((): MapDataQueryVariables => ({
         indicatorId,
         emergency: outbreakId,
@@ -386,17 +392,7 @@ function MapView(props: Props) {
         if (isNotDefined(regionId) && isNotDefined(countriesBoundList)) {
             return defaultBounds;
         }
-        if (isDefined(countriesBoundList)) {
-            const bounds = countriesBoundList.find(
-                (country) => country.properties.iso3 === countryCode,
-            )?.properties.bounding_box;
-            if (bounds) {
-                const [a, b, c, d] = bounds;
-                return [b, a, d, c];
-            }
-            return defaultBounds;
-        }
-        if (isDefined(regionId)) {
+        if (isDefined(regionId) && isNotDefined(countryCode)) {
             const regionData = regionBounds?.find(
                 (region) => region.region === regionId,
             );
@@ -407,6 +403,17 @@ function MapView(props: Props) {
             }
             return defaultBounds;
         }
+        if (isDefined(countriesBoundList) && isDefined(countryCode)) {
+            const bounds = countriesBoundList.find(
+                (country) => country.properties.iso3 === countryCode,
+            )?.properties.bounding_box;
+            if (bounds) {
+                const [a, b, c, d] = bounds;
+                return [b, a, d, c];
+            }
+            return defaultBounds;
+        }
+
         return defaultBounds;
     }, [
         regionId,


### PR DESCRIPTION
## Addresses:
- Mapbox issue of region bounds not being selected properly

## Changes:
- Add a logic to choose region bounds conditionally 

## This PR doesn't introduce any:
- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
